### PR TITLE
Fixed looping over list instead of map; added tests

### DIFF
--- a/table.go
+++ b/table.go
@@ -191,7 +191,8 @@ func (t *table) AppendBulk(rows [][]string) (err error) {
 // Print line based on row width
 func (t table) printLine(nl bool) {
 	fmt.Fprint(t.out, t.pCenter)
-	for _, v := range t.cs {
+	for i := 0; i < len(t.cs); i++ {
+		v := t.cs[i]
 		fmt.Fprintf(t.out, "%s%s%s%s",
 			t.pRow,
 			strings.Repeat(string(t.pRow), v),
@@ -218,7 +219,8 @@ func (t table) printHeading() {
 	end := len(t.cs) - 1
 
 	// Print Heading column
-	for i, v := range t.cs {
+	for i := 0; i <= end; i++ {
+		v := t.cs[i]
 		pad := ConditionString((i == end && !t.border), SPACE, t.pColumn)
 		fmt.Fprintf(t.out, " %s %s",
 			Pad(t.headers[i], SPACE, v),
@@ -248,7 +250,8 @@ func (t table) printFooter() {
 	end := len(t.cs) - 1
 
 	// Print Heading column
-	for i, v := range t.cs {
+	for i := 0; i <= end; i++ {
+		v := t.cs[i]
 		pad := ConditionString((i == end && !t.border), SPACE, t.pColumn)
 
 		if len(t.footers[i]) == 0 {
@@ -264,7 +267,8 @@ func (t table) printFooter() {
 
 	hasPrinted := false
 
-	for i, v := range t.cs {
+	for i := 0; i <= end; i++ {
+		v := t.cs[i]
 		pad := t.pRow
 		center := t.pCenter
 		length := len(t.footers[i])

--- a/table_test.go
+++ b/table_test.go
@@ -8,7 +8,10 @@
 package tablewriter
 
 import (
+	"bytes"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -97,4 +100,53 @@ func TestBorder(t *testing.T) {
 	table.SetBorder(false)                                // Set Border to false
 	table.AppendBulk(data)                                // Add Bulk Data
 	table.Render()
+}
+
+func TestPrintHeading(t *testing.T) {
+	var buf bytes.Buffer
+	table := NewWriter(&buf)
+	table.SetHeader([]string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c"})
+	table.printHeading()
+	want := `| 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | A | B | C |
++---+---+---+---+---+---+---+---+---+---+---+---+
+`
+	got := buf.String()
+	if got != want {
+		t.Errorf("header rendering failed\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
+func TestPrintFooter(t *testing.T) {
+	var buf bytes.Buffer
+	table := NewWriter(&buf)
+	table.SetHeader([]string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c"})
+	table.SetFooter([]string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c"})
+	table.printFooter()
+	want := `| 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | A | B | C |
++---+---+---+---+---+---+---+---+---+---+---+---+
+`
+	got := buf.String()
+	if got != want {
+		t.Errorf("footer rendering failed\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
+func TestPrintLine(t *testing.T) {
+	header := make([]string, 12)
+	val := " "
+	want := ""
+	for i := range header {
+		header[i] = val
+		want = fmt.Sprintf("%s+-%s-", want, strings.Replace(val, " ", "-", -1))
+		val = val + " "
+	}
+	want = want + "+"
+	var buf bytes.Buffer
+	table := NewWriter(&buf)
+	table.SetHeader(header)
+	table.printLine(false)
+	got := buf.String()
+	if got != want {
+		t.Errorf("line rendering failed\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
 }


### PR DESCRIPTION
Hi there,

just found that library that is very useful to me. However, there is a bug where the order of looping over the map keys is assumed to be known. Based on go 1.2 specs, there is no guarantee in the order (http://golang.org/ref/spec#RangeClause, point #3: "The iteration order over maps is not specified and is not guaranteed to be the same from one iteration to the next.").

That caused my headers to be in a weird order that didn't match the data. I fixed that and added some tests.

Let me know what you think.
