### PR TITLE
Compute column width using DisplayWidth

### DIFF
--- a/table.go
+++ b/table.go
@@ -421,7 +421,13 @@ func (t *Table) parseDimension(str string, colKey, rowKey int) []string {
 		return raw
 	}
 	// Calculate Height
-	raw, max = WrapString(str, t.cs[colKey])
+	raw, _ = WrapString(str, t.cs[colKey])
+
+	for _, line := range raw {
+		if w := DisplayWidth(line); w > max {
+			max = w
+		}
+	}
 
 	// Make sure the with is the same length as maximum word
 	// Important for cases where the width is smaller than maxu word


### PR DESCRIPTION
I was confused by the column widths:

![image](https://cloud.githubusercontent.com/assets/438648/5515226/d537c560-8859-11e4-9196-3baed414e30a.png)

This pull request fixes that. I don't know if the fix is optimal or not, but this PR can serve as an issue instead if not.

![image](https://cloud.githubusercontent.com/assets/438648/5515229/f8466ea8-8859-11e4-9b86-d8d05ed990e4.png)