### PR TITLE
Fix the decimal and percent regexps

### DIFF
--- a/table.go
+++ b/table.go
@@ -34,8 +34,8 @@ const (
 )
 
 var (
-	decimal = regexp.MustCompile(`^[0-9]+.[0-9]+$`)
-	percent = regexp.MustCompile(`^[0-9]+.[0-9]+%$`)
+	decimal = regexp.MustCompile(`^[0-9]+(.[0-9]+?)$`)
+	percent = regexp.MustCompile(`^[0-9]+(.[0-9]+?)%$`)
 )
 
 type Table struct {


### PR DESCRIPTION
Previously they wouldn't match things like '12' or '1%'