### PR TITLE
Autoformat headers

### DIFF
--- a/table.go
+++ b/table.go
@@ -46,6 +46,7 @@ type Table struct {
 	rs      map[int]int
 	headers []string
 	footers []string
+	autoFmt bool
 	mW      int
 	pCenter string
 	pRow    string
@@ -69,6 +70,7 @@ func NewWriter(writer io.Writer) *Table {
 		rs:      make(map[int]int),
 		headers: []string{},
 		footers: []string{},
+		autoFmt: true,
 		mW:      MAX_ROW_WIDTH,
 		pCenter: CENTRE,
 		pRow:    ROW,
@@ -113,6 +115,11 @@ func (t *Table) SetFooter(keys []string) {
 		t.parseDimension(v, i, -1)
 		t.footers = append(t.footers, v)
 	}
+}
+
+// Turn header autoformatting on/off. Default is on (true).
+func (t* Table) SetAutoFormatHeaders(auto bool) {
+	t.autoFmt = auto
 }
 
 // Set the Default column width
@@ -220,9 +227,13 @@ func (t Table) printHeading() {
 	// Print Heading column
 	for i := 0; i <= end; i++ {
 		v := t.cs[i]
+		h := t.headers[i]
+		if t.autoFmt {
+			h = Title(h)
+		}
 		pad := ConditionString((i == end && !t.border), SPACE, t.pColumn)
 		fmt.Fprintf(t.out, " %s %s",
-			Pad(Title(t.headers[i]), SPACE, v),
+			Pad(h, SPACE, v),
 			pad)
 	}
 	// Next line
@@ -251,13 +262,17 @@ func (t Table) printFooter() {
 	// Print Heading column
 	for i := 0; i <= end; i++ {
 		v := t.cs[i]
+		f := t.footers[i]
+		if t.autoFmt {
+			f = Title(f)
+		}
 		pad := ConditionString((i == end && !t.border), SPACE, t.pColumn)
 
 		if len(t.footers[i]) == 0 {
 			pad = SPACE
 		}
 		fmt.Fprintf(t.out, " %s %s",
-			Pad(Title(t.footers[i]), SPACE, v),
+			Pad(f, SPACE, v),
 			pad)
 	}
 	// Next line

--- a/table.go
+++ b/table.go
@@ -102,7 +102,7 @@ func (t *Table) SetHeader(keys []string) {
 	t.colSize = len(keys)
 	for i, v := range keys {
 		t.parseDimension(v, i, -1)
-		t.headers = append(t.headers, Title(v))
+		t.headers = append(t.headers, v)
 	}
 }
 
@@ -111,7 +111,7 @@ func (t *Table) SetFooter(keys []string) {
 	//t.colSize = len(keys)
 	for i, v := range keys {
 		t.parseDimension(v, i, -1)
-		t.footers = append(t.footers, Title(v))
+		t.footers = append(t.footers, v)
 	}
 }
 
@@ -222,7 +222,7 @@ func (t Table) printHeading() {
 		v := t.cs[i]
 		pad := ConditionString((i == end && !t.border), SPACE, t.pColumn)
 		fmt.Fprintf(t.out, " %s %s",
-			Pad(t.headers[i], SPACE, v),
+			Pad(Title(t.headers[i]), SPACE, v),
 			pad)
 	}
 	// Next line
@@ -257,7 +257,7 @@ func (t Table) printFooter() {
 			pad = SPACE
 		}
 		fmt.Fprintf(t.out, " %s %s",
-			Pad(t.footers[i], SPACE, v),
+			Pad(Title(t.footers[i]), SPACE, v),
 			pad)
 	}
 	// Next line

--- a/table_test.go
+++ b/table_test.go
@@ -117,6 +117,21 @@ func TestPrintHeading(t *testing.T) {
 	}
 }
 
+func TestPrintHeadingWithoutAutoFormat(t *testing.T) {
+	var buf bytes.Buffer
+	table := NewWriter(&buf)
+	table.SetHeader([]string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c"})
+	table.SetAutoFormatHeaders(false)
+	table.printHeading()
+	want := `| 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | a | b | c |
++---+---+---+---+---+---+---+---+---+---+---+---+
+`
+	got := buf.String()
+	if got != want {
+		t.Errorf("header rendering failed\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
 func TestPrintFooter(t *testing.T) {
 	var buf bytes.Buffer
 	table := NewWriter(&buf)
@@ -124,6 +139,22 @@ func TestPrintFooter(t *testing.T) {
 	table.SetFooter([]string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c"})
 	table.printFooter()
 	want := `| 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | A | B | C |
++---+---+---+---+---+---+---+---+---+---+---+---+
+`
+	got := buf.String()
+	if got != want {
+		t.Errorf("footer rendering failed\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
+func TestPrintFooterWithoutAutoFormat(t *testing.T) {
+	var buf bytes.Buffer
+	table := NewWriter(&buf)
+	table.SetAutoFormatHeaders(false)
+	table.SetHeader([]string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c"})
+	table.SetFooter([]string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c"})
+	table.printFooter()
+	want := `| 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | a | b | c |
 +---+---+---+---+---+---+---+---+---+---+---+---+
 `
 	got := buf.String()


### PR DESCRIPTION
Ref issue #15. `table.SetAutoFormatHeaders(false)` will turn off formatting. Can be called before or after `SetHeader` 

After writing this I had a look at issue #9 as well, and an implemention of that where you could call `table.SetTitleFunc(nil)` (or maybe `table.SetTitleFormat(nil)`?) to turn off formatting would work equally well for my use case. It may get confusing if both #9 and #15 are pulled in.