### PR TITLE
Optional multiline text wrapping

### DIFF
--- a/table.go
+++ b/table.go
@@ -120,7 +120,7 @@ func (t *Table) SetFooter(keys []string) {
 }
 
 // Turn header autoformatting on/off. Default is on (true).
-func (t* Table) SetAutoFormatHeaders(auto bool) {
+func (t *Table) SetAutoFormatHeaders(auto bool) {
 	t.autoFmt = auto
 }
 

--- a/table.go
+++ b/table.go
@@ -39,48 +39,50 @@ var (
 )
 
 type Table struct {
-	out     io.Writer
-	rows    [][]string
-	lines   [][][]string
-	cs      map[int]int
-	rs      map[int]int
-	headers []string
-	footers []string
-	autoFmt bool
-	mW      int
-	pCenter string
-	pRow    string
-	pColumn string
-	tColumn int
-	tRow    int
-	align   int
-	rowLine bool
-	border  bool
-	colSize int
+	out      io.Writer
+	rows     [][]string
+	lines    [][][]string
+	cs       map[int]int
+	rs       map[int]int
+	headers  []string
+	footers  []string
+	autoFmt  bool
+	autoWrap bool
+	mW       int
+	pCenter  string
+	pRow     string
+	pColumn  string
+	tColumn  int
+	tRow     int
+	align    int
+	rowLine  bool
+	border   bool
+	colSize  int
 }
 
 // Start New Table
 // Take io.Writer Directly
 func NewWriter(writer io.Writer) *Table {
 	t := &Table{
-		out:     writer,
-		rows:    [][]string{},
-		lines:   [][][]string{},
-		cs:      make(map[int]int),
-		rs:      make(map[int]int),
-		headers: []string{},
-		footers: []string{},
-		autoFmt: true,
-		mW:      MAX_ROW_WIDTH,
-		pCenter: CENTRE,
-		pRow:    ROW,
-		pColumn: COLUMN,
-		tColumn: -1,
-		tRow:    -1,
-		align:   ALIGN_DEFAULT,
-		rowLine: false,
-		border:  true,
-		colSize: -1}
+		out:      writer,
+		rows:     [][]string{},
+		lines:    [][][]string{},
+		cs:       make(map[int]int),
+		rs:       make(map[int]int),
+		headers:  []string{},
+		footers:  []string{},
+		autoFmt:  true,
+		autoWrap: true,
+		mW:       MAX_ROW_WIDTH,
+		pCenter:  CENTRE,
+		pRow:     ROW,
+		pColumn:  COLUMN,
+		tColumn:  -1,
+		tRow:     -1,
+		align:    ALIGN_DEFAULT,
+		rowLine:  false,
+		border:   true,
+		colSize:  -1}
 	return t
 }
 
@@ -120,6 +122,11 @@ func (t *Table) SetFooter(keys []string) {
 // Turn header autoformatting on/off. Default is on (true).
 func (t* Table) SetAutoFormatHeaders(auto bool) {
 	t.autoFmt = auto
+}
+
+// Turn automatic multiline text adjustment on/off. Default is on (true).
+func (t *Table) SetAutoWrapText(auto bool) {
+	t.autoWrap = auto
 }
 
 // Set the Default column width
@@ -436,7 +443,11 @@ func (t *Table) parseDimension(str string, colKey, rowKey int) []string {
 		return raw
 	}
 	// Calculate Height
-	raw, _ = WrapString(str, t.cs[colKey])
+	if t.autoWrap {
+		raw, _ = WrapString(str, t.cs[colKey])
+	} else {
+		raw = getLines(str)
+	}
 
 	for _, line := range raw {
 		if w := DisplayWidth(line); w > max {

--- a/table_test.go
+++ b/table_test.go
@@ -163,6 +163,40 @@ func TestPrintFooterWithoutAutoFormat(t *testing.T) {
 	}
 }
 
+func TestPrintTableWithAndWithoutAutoWrap(t *testing.T) {
+	var buf bytes.Buffer
+	var multiline = `A multiline
+string with some lines being really long.`
+
+	with := NewWriter(&buf)
+	with.Append([]string{multiline})
+	with.Render()
+	want := `+--------------------------------+
+| A multiline string with some   |
+| lines being really long.       |
++--------------------------------+
+`
+	got := buf.String()
+	if got != want {
+		t.Errorf("multiline text rendering with wrapping failed\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+
+	buf.Truncate(0)
+	without := NewWriter(&buf)
+	without.SetAutoWrapText(false)
+	without.Append([]string{multiline})
+	without.Render()
+	want = `+-------------------------------------------+
+| A multiline                               |
+| string with some lines being really long. |
++-------------------------------------------+
+`
+	got = buf.String()
+	if got != want {
+		t.Errorf("multiline text rendering without wrapping rendering failed\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
 func TestPrintLine(t *testing.T) {
 	header := make([]string, 12)
 	val := " "

--- a/wrap.go
+++ b/wrap.go
@@ -91,3 +91,13 @@ func WrapWords(words []string, spc, lim, pen int) [][]string {
 	}
 	return lines
 }
+
+// getLines decomposes a multiline string into a slice of strings.
+func getLines(s string) []string {
+	var lines []string
+
+	for _, line := range strings.Split(strings.TrimSpace(s), nl) {
+		lines = append(lines, line)
+	}
+	return lines
+}


### PR DESCRIPTION
Hello!

I've picked up this great library because of the need for the proper rendering of nested tables. Most of the times it just works but in some cases the inner table layout breaks because of the automatic text wrapping and, for example, instead of
```
+--------------------------------+
|      +--------+--------+       |
|      |  Path  | SizeGB |       |
|      +--------+--------+       |
|      | (swap) |   0    |       |
|      +--------+--------+       |
|      | /boot  | 0.474  |       |
|      +--------+--------+       |
+--------------------------------+

```
I see
```
+--------------------------------+
|  +--------+--------+ |  Path   |
| | SizeGB | +--------+--------+ |
|      | (swap) |   0    |       |
|  +--------+--------+ |   /     |
| | 13.655 | +--------+--------+ |
|      | /boot  | 0.474  |       |
|      +--------+--------+       |
+--------------------------------+
```
I think it's worth having an option of turning this feature off.

I've come up with a solution that introduces the SetAutoWrapText function allowing to turn off the automatic wrapping. It remains on by default so backwards compatibility is preserved. A small test included.

I am open to further discussion.

Thanks!