### PR TITLE
fix decimal and percent regex to allow numbers without '.'

### DIFF
--- a/table.go
+++ b/table.go
@@ -34,8 +34,8 @@ const (
 )
 
 var (
-	decimal = regexp.MustCompile(`^[0-9]+(.[0-9]+?)$`)
-	percent = regexp.MustCompile(`^[0-9]+(.[0-9]+?)%$`)
+	decimal = regexp.MustCompile(`^\d*\.?\d*$`)
+	percent = regexp.MustCompile(`^\d*\.?\d*$%$`)
 )
 
 type Table struct {


### PR DESCRIPTION
This forces all numbers to be right-aligned.