### PR TITLE
Fix unicode string width count

### DIFF
--- a/util.go
+++ b/util.go
@@ -11,23 +11,14 @@ import (
 	"math"
 	"regexp"
 	"strings"
-	"unicode/utf8"
+
+	"github.com/mattn/go-runewidth"
 )
 
-var (
-	ansi = regexp.MustCompile("\033\\[(?:[0-9]{1,3}(?:;[0-9]{1,3})*)?[m|K]")
-)
+var ansi = regexp.MustCompile("\033\\[(?:[0-9]{1,3}(?:;[0-9]{1,3})*)?[m|K]")
 
 func DisplayWidth(str string) int {
-	tmp := ansi.ReplaceAllLiteralString(str, "")
-	tmp_rune := []rune(tmp)
-	count := 0
-	for _, v := range tmp_rune {
-		if v > 128 {
-			count++
-		}
-	}
-	return utf8.RuneCountInString(tmp) + count
+	return runewidth.StringWidth(ansi.ReplaceAllLiteralString(str, ""))
 }
 
 // Simple Condition for string

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -42,3 +42,14 @@ func TestUnicode(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestDisplayWidth(t *testing.T) {
+	input := "Česká řeřicha"
+	if n := DisplayWidth(input); n != 13 {
+		t.Errorf("Wants: %d Got: %d", 13, n)
+	}
+	input = "\033[43;30m" + input + "\033[00m"
+	if n := DisplayWidth(input); n != 13 {
+		t.Errorf("Wants: %d Got: %d", 13, n)
+	}
+}


### PR DESCRIPTION
Unfortunately #18 did not fix the issue completely.

Before:
![](https://i.gyazo.com/dad1f82346dc51c7e8cd18e623ce9d63.png)

After:
![](https://i.gyazo.com/7daaa2484a23b8fb994b364f3a547878.png)

More [here](https://github.com/crackcomm/go-clitable/pull/3).

Again thanks to @mattn