### PR TITLE
Allow caption functionality for table

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Generate ASCII table on the fly ...  Installation is simple as
 - Make CSV Headers optional
 - Enable or disable table border
 - Set custom footer support
+- Set custom caption
 
 
 #### Example   1 - Basic
@@ -131,7 +132,7 @@ table.Render()
 *------------*-----------*---------*
 ```
 
-##### Example 5 - Markdown Format
+#### Example 5 - Markdown Format
 ```go
 data := [][]string{
 	[]string{"1/1/2014", "Domain name", "2233", "$10.98"},
@@ -156,6 +157,40 @@ table.Render()
 | 1/1/2014 | January Hosting          | 2233 | $54.95 |
 | 1/4/2014 | February Hosting         | 2233 | $51.00 |
 | 1/4/2014 | February Extra Bandwidth | 2233 | $30.00 |
+```
+
+#### Example 6 - Set table caption
+```go
+data := [][]string{
+    []string{"A", "The Good", "500"},
+    []string{"B", "The Very very Bad Man", "288"},
+    []string{"C", "The Ugly", "120"},
+    []string{"D", "The Gopher", "800"},
+}
+
+table := tablewriter.NewWriter(os.Stdout)
+table.SetHeader([]string{"Name", "Sign", "Rating"})
+table.SetCaption(true, "Movie ratings.")
+
+for _, v := range data {
+    table.Append(v)
+}
+table.Render() // Send output
+```
+
+Note: Caption text will wrap with total width of rendered table.
+
+##### Output 6
+```
++------+-----------------------+--------+
+| NAME |         SIGN          | RATING |
++------+-----------------------+--------+
+|  A   |       The Good        |    500 |
+|  B   | The Very very Bad Man |    288 |
+|  C   |       The Ugly        |    120 |
+|  D   |      The Gopher       |    800 |
++------+-----------------------+--------+
+Movie ratings.
 ```
 
 #### TODO

--- a/table.go
+++ b/table.go
@@ -46,56 +46,60 @@ type Border struct {
 }
 
 type Table struct {
-	out      io.Writer
-	rows     [][]string
-	lines    [][][]string
-	cs       map[int]int
-	rs       map[int]int
-	headers  []string
-	footers  []string
-	autoFmt  bool
-	autoWrap bool
-	mW       int
-	pCenter  string
-	pRow     string
-	pColumn  string
-	tColumn  int
-	tRow     int
-	hAlign   int
-	fAlign   int
-	align    int
-	rowLine  bool
-	hdrLine  bool
-	borders  Border
-	colSize  int
+	out         io.Writer
+	rows        [][]string
+	lines       [][][]string
+	cs          map[int]int
+	rs          map[int]int
+	headers     []string
+	footers     []string
+	caption     bool
+	captionText string
+	autoFmt     bool
+	autoWrap    bool
+	mW          int
+	pCenter     string
+	pRow        string
+	pColumn     string
+	tColumn     int
+	tRow        int
+	hAlign      int
+	fAlign      int
+	align       int
+	rowLine     bool
+	hdrLine     bool
+	borders     Border
+	colSize     int
 }
 
 // Start New Table
 // Take io.Writer Directly
 func NewWriter(writer io.Writer) *Table {
 	t := &Table{
-		out:      writer,
-		rows:     [][]string{},
-		lines:    [][][]string{},
-		cs:       make(map[int]int),
-		rs:       make(map[int]int),
-		headers:  []string{},
-		footers:  []string{},
-		autoFmt:  true,
-		autoWrap: true,
-		mW:       MAX_ROW_WIDTH,
-		pCenter:  CENTER,
-		pRow:     ROW,
-		pColumn:  COLUMN,
-		tColumn:  -1,
-		tRow:     -1,
-		hAlign:   ALIGN_DEFAULT,
-		fAlign:   ALIGN_DEFAULT,
-		align:    ALIGN_DEFAULT,
-		rowLine:  false,
-		hdrLine:  true,
-		borders:  Border{Left: true, Right: true, Bottom: true, Top: true},
-		colSize:  -1}
+		out:         writer,
+		rows:        [][]string{},
+		lines:       [][][]string{},
+		cs:          make(map[int]int),
+		rs:          make(map[int]int),
+		headers:     []string{},
+		footers:     []string{},
+		caption:     false,
+		captionText: "Table caption.",
+		autoFmt:     true,
+		autoWrap:    true,
+		mW:          MAX_ROW_WIDTH,
+		pCenter:     CENTER,
+		pRow:        ROW,
+		pColumn:     COLUMN,
+		tColumn:     -1,
+		tRow:        -1,
+		hAlign:      ALIGN_DEFAULT,
+		fAlign:      ALIGN_DEFAULT,
+		align:       ALIGN_DEFAULT,
+		rowLine:     false,
+		hdrLine:     true,
+		borders:     Border{Left: true, Right: true, Bottom: true, Top: true},
+		colSize:     -1}
 	return t
 }
 
@@ -111,7 +115,9 @@ func (t Table) Render() {
 		t.printLine(true)
 	}
 	t.printFooter()
-
+	if t.caption {
+		t.printCaption()
+	}
 }
 
 // Set table header
@@ -129,6 +135,14 @@ func (t *Table) SetFooter(keys []string) {
 	for i, v := range keys {
 		t.parseDimension(v, i, -1)
 		t.footers = append(t.footers, v)
+	}
+}
+
+// Set table Caption
+func (t *Table) SetCaption(caption bool, captionText ...string) {
+	t.caption = caption
+	if len(captionText) == 1 {
+		t.captionText = captionText[0]
 	}
 }
 
@@ -385,6 +399,28 @@ func (t Table) printFooter() {
 
 	fmt.Fprintln(t.out)
 
+}
+
+// Print caption text
+func (t Table) printCaption() {
+	width := t.getTableWidth()
+	// fmt.Fprintln(t.out, width)
+	paragraph, _ := WrapString(t.captionText, width)
+	for linecount := 0; linecount < len(paragraph); linecount++ {
+		fmt.Fprintln(t.out, paragraph[linecount])
+	}
+}
+
+// Calculate the total number of characters in a row
+func (t Table) getTableWidth() int {
+	var chars, spaces, ncols, seps int
+	for k, v := range t.cs {
+		chars += v
+		ncols = k + 1
+	}
+	spaces = ncols * 2
+	seps = ncols + 1
+	return (chars + spaces + seps + 1)
 }
 
 func (t Table) printRows() {

--- a/table.go
+++ b/table.go
@@ -404,7 +404,6 @@ func (t Table) printFooter() {
 // Print caption text
 func (t Table) printCaption() {
 	width := t.getTableWidth()
-	// fmt.Fprintln(t.out, width)
 	paragraph, _ := WrapString(t.captionText, width)
 	for linecount := 0; linecount < len(paragraph); linecount++ {
 		fmt.Fprintln(t.out, paragraph[linecount])
@@ -413,13 +412,13 @@ func (t Table) printCaption() {
 
 // Calculate the total number of characters in a row
 func (t Table) getTableWidth() int {
-	var chars, spaces, ncols, seps int
-	for k, v := range t.cs {
+	var chars int
+	for _, v := range t.cs {
 		chars += v
-		ncols = k + 1
 	}
-	spaces = ncols * 2
-	seps = ncols + 1
+	ncols := t.colSize
+	spaces := ncols * 2
+	seps := ncols + 1
 	return (chars + spaces + seps + 1)
 }
 

--- a/table.go
+++ b/table.go
@@ -416,10 +416,13 @@ func (t Table) getTableWidth() int {
 	for _, v := range t.cs {
 		chars += v
 	}
-	ncols := t.colSize
-	spaces := ncols * 2
-	seps := ncols + 1
-	return (chars + spaces + seps + 1)
+
+	// Add chars, spaces, seperators to calculate the total width of the table.
+	// ncols := t.colSize
+	// spaces := ncols * 2
+	// seps := ncols + 1
+
+	return (chars + (3 * t.colSize) + 2)
 }
 
 func (t Table) printRows() {

--- a/table_test.go
+++ b/table_test.go
@@ -311,6 +311,41 @@ that needs to be solved.
 	}
 }
 
+func TestPrintCaptionWithFooter(t *testing.T) {
+	data := [][]string{
+		[]string{"1/1/2014", "Domain name", "2233", "$10.98"},
+		[]string{"1/1/2014", "January Hosting", "2233", "$54.95"},
+		[]string{"1/4/2014", "February Hosting", "2233", "$51.00"},
+		[]string{"1/4/2014", "February Extra Bandwidth", "2233", "$30.00"},
+	}
+
+	var buf bytes.Buffer
+	table := NewWriter(&buf)
+	table.SetHeader([]string{"Date", "Description", "CV2", "Amount"})
+	table.SetFooter([]string{"", "", "Total", "$146.93"})                                                  // Add Footer
+	table.SetCaption(true, "This is a very long caption. The text should wrap to the width of the table.") // Add caption
+	table.SetBorder(false)                                                                                 // Set Border to false
+	table.AppendBulk(data)                                                                                 // Add Bulk Data
+	table.Render()
+
+	want := `    DATE   |       DESCRIPTION        |  CV2  | AMOUNT   
++----------+--------------------------+-------+---------+
+  1/1/2014 | Domain name              |  2233 | $10.98   
+  1/1/2014 | January Hosting          |  2233 | $54.95   
+  1/4/2014 | February Hosting         |  2233 | $51.00   
+  1/4/2014 | February Extra Bandwidth |  2233 | $30.00   
++----------+--------------------------+-------+---------+
+                                        TOTAL | $146 93  
+                                      +-------+---------+
+This is a very long caption. The text should wrap to the
+width of the table.
+`
+	got := buf.String()
+	if got != want {
+		t.Errorf("border table rendering failed\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
 func TestPrintLongCaptionWithLongExample(t *testing.T) {
 	var buf bytes.Buffer
 	data := [][]string{

--- a/table_test.go
+++ b/table_test.go
@@ -241,6 +241,110 @@ func TestPrintFooterWithoutAutoFormat(t *testing.T) {
 	}
 }
 
+func TestPrintShortCaption(t *testing.T) {
+	var buf bytes.Buffer
+	data := [][]string{
+		[]string{"A", "The Good", "500"},
+		[]string{"B", "The Very very Bad Man", "288"},
+		[]string{"C", "The Ugly", "120"},
+		[]string{"D", "The Gopher", "800"},
+	}
+
+	table := NewWriter(&buf)
+	table.SetHeader([]string{"Name", "Sign", "Rating"})
+	table.SetCaption(true, "Short caption.")
+
+	for _, v := range data {
+		table.Append(v)
+	}
+	table.Render()
+
+	want := `+------+-----------------------+--------+
+| NAME |         SIGN          | RATING |
++------+-----------------------+--------+
+| A    | The Good              |    500 |
+| B    | The Very very Bad Man |    288 |
+| C    | The Ugly              |    120 |
+| D    | The Gopher            |    800 |
++------+-----------------------+--------+
+Short caption.
+`
+	got := buf.String()
+	if got != want {
+		t.Errorf("long caption for short example rendering failed\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
+func TestPrintLongCaptionWithShortExample(t *testing.T) {
+	var buf bytes.Buffer
+	data := [][]string{
+		[]string{"A", "The Good", "500"},
+		[]string{"B", "The Very very Bad Man", "288"},
+		[]string{"C", "The Ugly", "120"},
+		[]string{"D", "The Gopher", "800"},
+	}
+
+	table := NewWriter(&buf)
+	table.SetHeader([]string{"Name", "Sign", "Rating"})
+	table.SetCaption(true, "This is a very long caption. The text should wrap. If not, we have a problem that needs to be solved.")
+
+	for _, v := range data {
+		table.Append(v)
+	}
+	table.Render()
+
+	want := `+------+-----------------------+--------+
+| NAME |         SIGN          | RATING |
++------+-----------------------+--------+
+| A    | The Good              |    500 |
+| B    | The Very very Bad Man |    288 |
+| C    | The Ugly              |    120 |
+| D    | The Gopher            |    800 |
++------+-----------------------+--------+
+This is a very long caption. The text
+should wrap. If not, we have a problem
+that needs to be solved.
+`
+	got := buf.String()
+	if got != want {
+		t.Errorf("long caption for short example rendering failed\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
+func TestPrintLongCaptionWithLongExample(t *testing.T) {
+	var buf bytes.Buffer
+	data := [][]string{
+		[]string{"Learn East has computers with adapted keyboards with enlarged print etc", "Some Data", "Another Data"},
+		[]string{"Instead of lining up the letters all", "the way across, he splits the keyboard in two", "Like most ergonomic keyboards"},
+	}
+
+	table := NewWriter(&buf)
+	table.SetCaption(true, "This is a very long caption. The text should wrap. If not, we have a problem that needs to be solved.")
+	table.SetHeader([]string{"Name", "Sign", "Rating"})
+
+	for _, v := range data {
+		table.Append(v)
+	}
+	table.Render()
+
+	want := `+--------------------------------+--------------------------------+-------------------------------+
+|              NAME              |              SIGN              |            RATING             |
++--------------------------------+--------------------------------+-------------------------------+
+| Learn East has computers       | Some Data                      | Another Data                  |
+| with adapted keyboards with    |                                |                               |
+| enlarged print etc             |                                |                               |
+| Instead of lining up the       | the way across, he splits the  | Like most ergonomic keyboards |
+| letters all                    | keyboard in two                |                               |
++--------------------------------+--------------------------------+-------------------------------+
+This is a very long caption. The text should wrap. If not, we have a problem that needs to be
+solved.
+`
+	got := buf.String()
+	if got != want {
+		t.Errorf("long caption for long example rendering failed\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
 func TestPrintTableWithAndWithoutAutoWrap(t *testing.T) {
 	var buf bytes.Buffer
 	var multiline = `A multiline


### PR DESCRIPTION
#### Example - Set table caption

``` go
data := [][]string{
    []string{"A", "The Good", "500"},
    []string{"B", "The Very very Bad Man", "288"},
    []string{"C", "The Ugly", "120"},
    []string{"D", "The Gopher", "800"},
}

table := tablewriter.NewWriter(os.Stdout)
table.SetHeader([]string{"Name", "Sign", "Rating"})
table.SetCaption(true, "Movie ratings.")

for _, v := range data {
    table.Append(v)
}
table.Render() // Send output
```

Note: Caption text will wrap with total width of rendered table.
##### Output

```
+------+-----------------------+--------+
| NAME |         SIGN          | RATING |
+------+-----------------------+--------+
|  A   |       The Good        |    500 |
|  B   | The Very very Bad Man |    288 |
|  C   |       The Ugly        |    120 |
|  D   |      The Gopher       |    800 |
+------+-----------------------+--------+
Movie ratings.
```
