### PR TITLE
Updated regexps to support right aligned negative values.

### DIFF
--- a/table.go
+++ b/table.go
@@ -34,8 +34,8 @@ const (
 )
 
 var (
-	decimal = regexp.MustCompile(`^\d*\.?\d*$`)
-	percent = regexp.MustCompile(`^\d*\.?\d*$%$`)
+	decimal = regexp.MustCompile(`^-*\d*\.?\d*$`)
+	percent = regexp.MustCompile(`^-*\d*\.?\d*$%$`)
 )
 
 type Border struct {


### PR DESCRIPTION
I noticed negative values (ex "-4") wouldn't be picked up as a numerical value by the decimal regexp. This was my quick local fix for it.