### PR TITLE
fix wrong CJK Character width

### DIFF
--- a/util.go
+++ b/util.go
@@ -9,17 +9,13 @@ package tablewriter
 
 import (
 	"math"
-	"regexp"
 	"strings"
-	"unicode/utf8"
-)
 
-var (
-	ansi = regexp.MustCompile("\033\\[(?:[0-9]{1,3}(?:;[0-9]{1,3})*)?[m|K]")
+	"github.com/mattn/go-runewidth"
 )
 
 func DisplayWidth(str string) int {
-	return utf8.RuneCountInString(ansi.ReplaceAllLiteralString(str, ""))
+	return runewidth.StringWidth(str)
 }
 
 // Simple Condition for string


### PR DESCRIPTION
Related issue https://github.com/olekukonko/tablewriter/pull/18,  https://github.com/olekukonko/tablewriter/pull/22

Width of unicode strings are not same as letter count.

before

![before](http://go-gyazo.appspot.com/f7e6cbbb868b3094.png)

after

![after](http://go-gyazo.appspot.com/18c800e44a31f58e.png)
