### PR TITLE
Preserve leading and trailing spaces in Append.

### DIFF
--- a/table_test.go
+++ b/table_test.go
@@ -93,12 +93,13 @@ func TestNoBorder(t *testing.T) {
 		[]string{"1/1/2014", "January Hosting", "2233", "$54.95"},
 		[]string{"1/4/2014", "February Hosting", "2233", "$51.00"},
 		[]string{"1/4/2014", "February Extra Bandwidth", "2233", "$30.00"},
+		[]string{"1/4/2014", "    (Discount)", "2233", "-$1.00"},
 	}
 
 	var buf bytes.Buffer
 	table := NewWriter(&buf)
 	table.SetHeader([]string{"Date", "Description", "CV2", "Amount"})
-	table.SetFooter([]string{"", "", "Total", "$146.93"}) // Add Footer
+	table.SetFooter([]string{"", "", "Total", "$145.93"}) // Add Footer
 	table.SetBorder(false)                                // Set Border to false
 	table.AppendBulk(data)                                // Add Bulk Data
 	table.Render()
@@ -109,8 +110,9 @@ func TestNoBorder(t *testing.T) {
   1/1/2014 | January Hosting          |  2233 | $54.95   
   1/4/2014 | February Hosting         |  2233 | $51.00   
   1/4/2014 | February Extra Bandwidth |  2233 | $30.00   
+  1/4/2014 |     (Discount)           |  2233 | -$1.00   
 +----------+--------------------------+-------+---------+
-                                        TOTAL | $146 93  
+                                        TOTAL | $145 93  
                                       +-------+---------+
 `
 	got := buf.String()
@@ -125,12 +127,13 @@ func TestWithBorder(t *testing.T) {
 		[]string{"1/1/2014", "January Hosting", "2233", "$54.95"},
 		[]string{"1/4/2014", "February Hosting", "2233", "$51.00"},
 		[]string{"1/4/2014", "February Extra Bandwidth", "2233", "$30.00"},
+		[]string{"1/4/2014", "    (Discount)", "2233", "-$1.00"},
 	}
 
 	var buf bytes.Buffer
 	table := NewWriter(&buf)
 	table.SetHeader([]string{"Date", "Description", "CV2", "Amount"})
-	table.SetFooter([]string{"", "", "Total", "$146.93"}) // Add Footer
+	table.SetFooter([]string{"", "", "Total", "$145.93"}) // Add Footer
 	table.AppendBulk(data)                                // Add Bulk Data
 	table.Render()
 
@@ -141,8 +144,9 @@ func TestWithBorder(t *testing.T) {
 | 1/1/2014 | January Hosting          |  2233 | $54.95  |
 | 1/4/2014 | February Hosting         |  2233 | $51.00  |
 | 1/4/2014 | February Extra Bandwidth |  2233 | $30.00  |
+| 1/4/2014 |     (Discount)           |  2233 | -$1.00  |
 +----------+--------------------------+-------+---------+
-|                                       TOTAL | $146 93 |
+|                                       TOTAL | $145 93 |
 +----------+--------------------------+-------+---------+
 `
 	got := buf.String()

--- a/wrap.go
+++ b/wrap.go
@@ -23,7 +23,7 @@ const defaultPenalty = 1e5
 // Wrap wraps s into a paragraph of lines of length lim, with minimal
 // raggedness.
 func WrapString(s string, lim int) ([]string, int) {
-	words := strings.Split(strings.Replace(strings.TrimSpace(s), nl, sp, -1), sp)
+	words := strings.Split(strings.Replace(s, nl, sp, -1), sp)
 	var lines []string
 	max := 0
 	for _, v := range words {


### PR DESCRIPTION
Fixes #52.

I decided to change WrapSpaces to never trim spaces, because I figured that the job of `tablewriter` is to preserve the data provided by the client application, no matter what it is; if a client needs to trim they can also do it themselves!