### PR TITLE
Preserve spaces

### DIFF
--- a/table_test.go
+++ b/table_test.go
@@ -98,6 +98,7 @@ func TestNoBorder(t *testing.T) {
 	data := [][]string{
 		[]string{"1/1/2014", "Domain name", "2233", "$10.98"},
 		[]string{"1/1/2014", "January Hosting", "2233", "$54.95"},
+		[]string{"", "    (empty)\n    (empty)", "", ""},
 		[]string{"1/4/2014", "February Hosting", "2233", "$51.00"},
 		[]string{"1/4/2014", "February Extra Bandwidth", "2233", "$30.00"},
 		[]string{"1/4/2014", "    (Discount)", "2233", "-$1.00"},
@@ -105,6 +106,7 @@ func TestNoBorder(t *testing.T) {
 
 	var buf bytes.Buffer
 	table := NewWriter(&buf)
+	table.SetAutoWrapText(false)
 	table.SetHeader([]string{"Date", "Description", "CV2", "Amount"})
 	table.SetFooter([]string{"", "", "Total", "$145.93"}) // Add Footer
 	table.SetBorder(false)                                // Set Border to false
@@ -115,6 +117,8 @@ func TestNoBorder(t *testing.T) {
 +----------+--------------------------+-------+---------+
   1/1/2014 | Domain name              |  2233 | $10.98   
   1/1/2014 | January Hosting          |  2233 | $54.95   
+           |     (empty)              |       |          
+           |     (empty)              |       |          
   1/4/2014 | February Hosting         |  2233 | $51.00   
   1/4/2014 | February Extra Bandwidth |  2233 | $30.00   
   1/4/2014 |     (Discount)           |  2233 | -$1.00   
@@ -132,6 +136,7 @@ func TestWithBorder(t *testing.T) {
 	data := [][]string{
 		[]string{"1/1/2014", "Domain name", "2233", "$10.98"},
 		[]string{"1/1/2014", "January Hosting", "2233", "$54.95"},
+		[]string{"", "    (empty)\n    (empty)", "", ""},
 		[]string{"1/4/2014", "February Hosting", "2233", "$51.00"},
 		[]string{"1/4/2014", "February Extra Bandwidth", "2233", "$30.00"},
 		[]string{"1/4/2014", "    (Discount)", "2233", "-$1.00"},
@@ -139,6 +144,7 @@ func TestWithBorder(t *testing.T) {
 
 	var buf bytes.Buffer
 	table := NewWriter(&buf)
+	table.SetAutoWrapText(false)
 	table.SetHeader([]string{"Date", "Description", "CV2", "Amount"})
 	table.SetFooter([]string{"", "", "Total", "$145.93"}) // Add Footer
 	table.AppendBulk(data)                                // Add Bulk Data
@@ -149,6 +155,8 @@ func TestWithBorder(t *testing.T) {
 +----------+--------------------------+-------+---------+
 | 1/1/2014 | Domain name              |  2233 | $10.98  |
 | 1/1/2014 | January Hosting          |  2233 | $54.95  |
+|          |     (empty)              |       |         |
+|          |     (empty)              |       |         |
 | 1/4/2014 | February Hosting         |  2233 | $51.00  |
 | 1/4/2014 | February Extra Bandwidth |  2233 | $30.00  |
 | 1/4/2014 |     (Discount)           |  2233 | -$1.00  |

--- a/wrap.go
+++ b/wrap.go
@@ -96,7 +96,7 @@ func WrapWords(words []string, spc, lim, pen int) [][]string {
 func getLines(s string) []string {
 	var lines []string
 
-	for _, line := range strings.Split(strings.TrimSpace(s), nl) {
+	for _, line := range strings.Split(s, nl) {
 		lines = append(lines, line)
 	}
 	return lines

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -32,7 +32,7 @@ func TestWrapOneLine(t *testing.T) {
 	words, _ := WrapString(text, 500)
 	got := strings.Join(words, string(sp))
 	if exp != got {
-		t.Fail()
+		t.Errorf("expected: %q, got: %q", exp, got)
 	}
 }
 


### PR DESCRIPTION
The patch in #56 (to fix #52) was incomplete, and would only make a difference if AutoWrapText was enabled.

This PR complements the change to make it work when AutoWrapText is disabled.