### PR TITLE
Add function to set minimal column width

### DIFF
--- a/table.go
+++ b/table.go
@@ -156,6 +156,11 @@ func (t *Table) SetColWidth(width int) {
 	t.mW = width
 }
 
+// Set the minimal width for a column
+func (t *Table) SetColMinWidth(column int, width int) {
+    t.cs[column] = width
+}
+
 // Set the Column Separator
 func (t *Table) SetColumnSeparator(sep string) {
 	t.pColumn = sep


### PR DESCRIPTION
Hello.

This PR adds a function to set minimal column width. This is useful, for example, when you're generating multiple tables in goroutines and the column width is different in different routines. 
With this setting you can pre configure your column with dynamic output length to a known size 
(I calculate the maximum width by getting terminal width)