### PR TITLE
Fixed panics due to out-of-bounds slice index access.

### DIFF
--- a/table.go
+++ b/table.go
@@ -330,7 +330,10 @@ func (t *Table) printHeading() {
 	// Print Heading column
 	for i := 0; i <= end; i++ {
 		v := t.cs[i]
-		h := t.headers[i]
+		h := ""
+		if i < len(t.headers) {
+			h = t.headers[i]
+		}
 		if t.autoFmt {
 			h = Title(h)
 		}

--- a/table_test.go
+++ b/table_test.go
@@ -599,3 +599,64 @@ func TestClearFooters(t *testing.T) {
 		t.Errorf("table clear rows failed\ngot:\n%s\nwant:\n%s\n", got, want)
 	}
 }
+
+func TestMoreDataColumnsThanHeaders(t *testing.T) {
+	var (
+		buf    = &bytes.Buffer{}
+		table  = NewWriter(buf)
+		header = []string{"A", "B", "C"}
+		data   = [][]string{
+			[]string{"a", "b", "c", "d"},
+			[]string{"1", "2", "3", "4"},
+		}
+		want = `+---+---+---+---+
+| A | B | C |   |
++---+---+---+---+
+| a | b | c | d |
+| 1 | 2 | 3 | 4 |
++---+---+---+---+
+`
+	)
+	table.SetHeader(header)
+	// table.SetFooter(ctx.tableCtx.footer)
+	table.AppendBulk(data)
+	table.Render()
+
+	got := buf.String()
+
+	if got != want {
+		t.Errorf("\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}
+
+func TestMoreFooterColumnsThanHeaders(t *testing.T) {
+	var (
+		buf    = &bytes.Buffer{}
+		table  = NewWriter(buf)
+		header = []string{"A", "B", "C"}
+		data   = [][]string{
+			[]string{"a", "b", "c", "d"},
+			[]string{"1", "2", "3", "4"},
+		}
+		footer = []string{"a", "b", "c", "d", "e"}
+		want   = `+---+---+---+---+---+
+| A | B | C |   |   |
++---+---+---+---+---+
+| a | b | c | d |
+| 1 | 2 | 3 | 4 |
++---+---+---+---+---+
+| A | B | C | D | E |
++---+---+---+---+---+
+`
+	)
+	table.SetHeader(header)
+	table.SetFooter(footer)
+	table.AppendBulk(data)
+	table.Render()
+
+	got := buf.String()
+
+	if got != want {
+		t.Errorf("\ngot:\n%s\nwant:\n%s\n", got, want)
+	}
+}


### PR DESCRIPTION
Fixed panics due to out-of-bounds slice index access.

There was a panic due to OOB slice access when there were more data columns than
header columns.

Includes corresponding test case as well as test for more footer columns than
header columns.

Fixes https://github.com/jaytaylor/html2text/issues/20.