### PR TITLE
color table content added

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,43 @@ table.Render()
 +----------+--------------------------+-------+---------+
 ```
 
+
+#### Table with color
+```go
+data := [][]string{
+    []string{"1/1/2014", "Domain name", "2233", "$10.98"},
+    []string{"1/1/2014", "January Hosting", "2233", "$54.95"},
+    []string{"1/4/2014", "February Hosting", "2233", "$51.00"},
+    []string{"1/4/2014", "February Extra Bandwidth", "2233", "$30.00"},
+}
+
+table := tablewriter.NewWriter(os.Stdout)
+table.SetHeader([]string{"Date", "Description", "CV2", "Amount"})
+table.SetFooter([]string{"", "", "Total", "$146.93"}) // Add Footer
+table.SetBorder(false)                                // Set Border to false
+
+table.SetHeaderAttributes(tablewriter.Add(tablewriter.Bold, tablewriter.BgGreenColor),
+			  tablewriter.Add(tablewriter.FgHiRedColor, tablewriter.Bold, tablewriter.BgBlackColor),
+			  tablewriter.Add(tablewriter.BgRedColor, tablewriter.FgWhiteColor),
+	  		  tablewriter.Add(tablewriter.BgCyanColor, tablewriter.FgWhiteColor))
+
+table.SetColumnAttributes(tablewriter.Add(tablewriter.Bold, tablewriter.FgHiBlackColor),
+			  tablewriter.Add(tablewriter.Bold, tablewriter.FgHiRedColor),
+			  tablewriter.Add(tablewriter.Bold, tablewriter.FgHiBlackColor),
+			  tablewriter.Add(tablewriter.Bold, tablewriter.FgBlackColor))
+
+table.SetFooterAttributes(tablewriter.Add(), tablewriter.Add(),
+                          tablewriter.Add(tablewriter.Bold),
+                          tablewriter.Add(tablewriter.FgHiRedColor))
+
+table.AppendBulk(data)
+table.Render()
+```
+
+#### Table with color Output
+![Table with Color](https://cloud.githubusercontent.com/assets/6460392/21101956/bbc7b356-c0a1-11e6-9f36-dba694746efc.png)
+
+
 #### TODO
 - ~~Import Directly from CSV~~  - `done`
 - ~~Support for `SetFooter`~~  - `done`
@@ -202,3 +239,5 @@ table.Render()
 - Support custom alignment
 - General Improvement & Optimisation
 - `NewHTML` Parse table from HTML
+
+

--- a/table_test.go
+++ b/table_test.go
@@ -14,8 +14,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/mattn/go-runewidth"
 )
 
 func ExampleShort() {
@@ -109,26 +107,21 @@ func TestCSVSeparator(t *testing.T) {
 		return
 	}
 	table.SetRowLine(true)
-	if runewidth.IsEastAsian() {
-		table.SetCenterSeparator("＊")
-		table.SetColumnSeparator("‡")
-	} else {
-		table.SetCenterSeparator("*")
-		table.SetColumnSeparator("‡")
-	}
+	table.SetCenterSeparator("+")
+	table.SetColumnSeparator("|")
 	table.SetRowSeparator("-")
 	table.SetAlignment(ALIGN_LEFT)
 	table.Render()
 
-	want := `*------------*-----------*---------*
-‡ FIRST NAME ‡ LAST NAME ‡   SSN   ‡
-*------------*-----------*---------*
-‡ John       ‡ Barry     ‡ 123456  ‡
-*------------*-----------*---------*
-‡ Kathy      ‡ Smith     ‡ 687987  ‡
-*------------*-----------*---------*
-‡ Bob        ‡ McCornick ‡ 3979870 ‡
-*------------*-----------*---------*
+	want := `+------------+-----------+---------+
+| FIRST NAME | LAST NAME |   SSN   |
++------------+-----------+---------+
+| John       | Barry     | 123456  |
++------------+-----------+---------+
+| Kathy      | Smith     | 687987  |
++------------+-----------+---------+
+| Bob        | McCornick | 3979870 |
++------------+-----------+---------+
 `
 
 	got := buf.String()

--- a/table_with_color.go
+++ b/table_with_color.go
@@ -1,0 +1,138 @@
+package tablewriter
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const ESC = "\033"
+const SEP = ";"
+
+const (
+	BgBlackColor int = iota + 40
+	BgRedColor
+	BgGreenColor
+	BgYellowColor
+	BgBlueColor
+	BgMagentaColor
+	BgCyanColor
+	BgWhiteColor
+)
+
+const (
+	FgBlackColor int = iota + 30
+	FgRedColor
+	FgGreenColor
+	FgYellowColor
+	FgBlueColor
+	FgMagentaColor
+	FgCyanColor
+	FgWhiteColor
+)
+
+const (
+	BgHiBlackColor int = iota + 100
+	BgHiRedColor
+	BgHiGreenColor
+	BgHiYellowColor
+	BgHiBlueColor
+	BgHiMagentaColor
+	BgHiCyanColor
+	BgHiWhiteColor
+)
+
+const (
+	FgHiBlackColor int = iota + 90
+	FgHiRedColor
+	FgHiGreenColor
+	FgHiYellowColor
+	FgHiBlueColor
+	FgHiMagentaColor
+	FgHiCyanColor
+	FgHiWhiteColor
+)
+
+const (
+	Normal = 0
+	Bold = 1
+	UnderlineSingle = 4
+	Italic
+
+)
+
+type Values []int
+
+
+func startFormat(seq string) string{
+	return fmt.Sprintf("%s[%sm", ESC, seq)
+}
+
+func stopFormat() string{
+	return fmt.Sprintf("%s[%dm", ESC, Normal)
+}
+
+// Making the SGR (Select Graphic Rendition) sequence.
+func makeSequence(codes []int) string{
+	codesInString := []string{}
+	for _, code := range codes{
+		codesInString = append(codesInString, strconv.Itoa(code))
+	}
+	return strings.Join(codesInString, SEP)
+}
+
+// Adding ANSI escape  sequences before and after string
+func format(s string, codes interface{}) string{
+	var seq string
+
+	switch v := codes.(type) {
+
+		case string:
+			seq = v
+		case []int:
+			seq = makeSequence(v)
+		default:
+			return s
+	}
+
+	if len(seq) == 0{
+		return s
+	}
+	return startFormat(seq) + s + stopFormat()
+}
+
+
+// Adding header attributes (ANSI codes)
+func (t *Table) SetHeaderAttributes(args ...Values){
+	if t.colSize != len(args){
+		panic("Number of header attributes must be equal to number of headers.")
+	}
+	for i:=0 ; i < len(args); i ++ {
+		t.headerParams = append(t.headerParams, makeSequence(args[i]))
+	}
+}
+
+// Adding column attributes (ANSI codes)
+func (t *Table) SetColumnAttributes(args ...Values){
+	if t.colSize != len(args){
+		panic("Number of column attributes must be equal to number of headers.")
+	}
+	for i:=0 ; i < len(args); i ++ {
+		t.columnsParams = append(t.columnsParams, makeSequence(args[i]))
+	}
+}
+
+// Adding column attributes (ANSI codes)
+func (t *Table) SetFooterAttributes(args ...Values){
+	if len(t.footers) != len(args){
+		panic("Number of footer attributes must be equal to number of footer.")
+	}
+	for i:=0 ; i < len(args); i ++ {
+		t.footerParams = append(t.footerParams, makeSequence(args[i]))
+	}
+}
+
+
+func Add(values ...int) []int{
+	return values
+}

--- a/table_with_color.go
+++ b/table_with_color.go
@@ -54,85 +54,81 @@ const (
 )
 
 const (
-	Normal = 0
-	Bold = 1
+	Normal          = 0
+	Bold            = 1
 	UnderlineSingle = 4
 	Italic
-
 )
 
 type Values []int
 
-
-func startFormat(seq string) string{
+func startFormat(seq string) string {
 	return fmt.Sprintf("%s[%sm", ESC, seq)
 }
 
-func stopFormat() string{
+func stopFormat() string {
 	return fmt.Sprintf("%s[%dm", ESC, Normal)
 }
 
 // Making the SGR (Select Graphic Rendition) sequence.
-func makeSequence(codes []int) string{
+func makeSequence(codes []int) string {
 	codesInString := []string{}
-	for _, code := range codes{
+	for _, code := range codes {
 		codesInString = append(codesInString, strconv.Itoa(code))
 	}
 	return strings.Join(codesInString, SEP)
 }
 
 // Adding ANSI escape  sequences before and after string
-func format(s string, codes interface{}) string{
+func format(s string, codes interface{}) string {
 	var seq string
 
 	switch v := codes.(type) {
 
-		case string:
-			seq = v
-		case []int:
-			seq = makeSequence(v)
-		default:
-			return s
+	case string:
+		seq = v
+	case []int:
+		seq = makeSequence(v)
+	default:
+		return s
 	}
 
-	if len(seq) == 0{
+	if len(seq) == 0 {
 		return s
 	}
 	return startFormat(seq) + s + stopFormat()
 }
 
-
-// Adding header attributes (ANSI codes)
-func (t *Table) SetHeaderAttributes(args ...Values){
-	if t.colSize != len(args){
-		panic("Number of header attributes must be equal to number of headers.")
+// Adding header colors (ANSI codes)
+func (t *Table) SetHeaderColor(args ...Values) {
+	if t.colSize != len(args) {
+		panic("Number of header colors must be equal to number of headers.")
 	}
-	for i:=0 ; i < len(args); i ++ {
+	for i := 0; i < len(args); i++ {
 		t.headerParams = append(t.headerParams, makeSequence(args[i]))
 	}
 }
 
-// Adding column attributes (ANSI codes)
-func (t *Table) SetColumnAttributes(args ...Values){
-	if t.colSize != len(args){
-		panic("Number of column attributes must be equal to number of headers.")
+// Adding column colors (ANSI codes)
+func (t *Table) SetColumnColor(args ...Values) {
+	if t.colSize != len(args) {
+		panic("Number of column colors must be equal to number of headers.")
 	}
-	for i:=0 ; i < len(args); i ++ {
+	for i := 0; i < len(args); i++ {
 		t.columnsParams = append(t.columnsParams, makeSequence(args[i]))
 	}
 }
 
-// Adding column attributes (ANSI codes)
-func (t *Table) SetFooterAttributes(args ...Values){
-	if len(t.footers) != len(args){
-		panic("Number of footer attributes must be equal to number of footer.")
+// Adding column colors (ANSI codes)
+func (t *Table) SetFooterColor(args ...Values) {
+	if len(t.footers) != len(args) {
+		panic("Number of footer colors must be equal to number of footer.")
 	}
-	for i:=0 ; i < len(args); i ++ {
+	for i := 0; i < len(args); i++ {
 		t.footerParams = append(t.footerParams, makeSequence(args[i]))
 	}
 }
 
-
-func Add(values ...int) []int{
+func Add(values ...int) []int {
 	return values
 }

--- a/table_with_color.go
+++ b/table_with_color.go
@@ -60,7 +60,7 @@ const (
 	Italic
 )
 
-type Values []int
+type Colors []int
 
 func startFormat(seq string) string {
 	return fmt.Sprintf("%s[%sm", ESC, seq)
@@ -100,35 +100,35 @@ func format(s string, codes interface{}) string {
 }
 
 // Adding header colors (ANSI codes)
-func (t *Table) SetHeaderColor(args ...Values) {
-	if t.colSize != len(args) {
+func (t *Table) SetHeaderColor(colors ...Colors) {
+	if t.colSize != len(colors) {
 		panic("Number of header colors must be equal to number of headers.")
 	}
-	for i := 0; i < len(args); i++ {
-		t.headerParams = append(t.headerParams, makeSequence(args[i]))
+	for i := 0; i < len(colors); i++ {
+		t.headerParams = append(t.headerParams, makeSequence(colors[i]))
 	}
 }
 
 // Adding column colors (ANSI codes)
-func (t *Table) SetColumnColor(args ...Values) {
-	if t.colSize != len(args) {
+func (t *Table) SetColumnColor(colors ...Colors) {
+	if t.colSize != len(colors) {
 		panic("Number of column colors must be equal to number of headers.")
 	}
-	for i := 0; i < len(args); i++ {
-		t.columnsParams = append(t.columnsParams, makeSequence(args[i]))
+	for i := 0; i < len(colors); i++ {
+		t.columnsParams = append(t.columnsParams, makeSequence(colors[i]))
 	}
 }
 
 // Adding column colors (ANSI codes)
-func (t *Table) SetFooterColor(args ...Values) {
-	if len(t.footers) != len(args) {
+func (t *Table) SetFooterColor(colors ...Colors) {
+	if len(t.footers) != len(colors) {
 		panic("Number of footer colors must be equal to number of footer.")
 	}
-	for i := 0; i < len(args); i++ {
-		t.footerParams = append(t.footerParams, makeSequence(args[i]))
+	for i := 0; i < len(colors); i++ {
+		t.footerParams = append(t.footerParams, makeSequence(colors[i]))
 	}
 }
 
-func Add(values ...int) []int {
-	return values
+func Color(colors ...int) []int {
+	return colors
 }


### PR DESCRIPTION
@olekukonko I rebased #50 

```go
package main

import (
	"github.com/mattn/go-colorable"
	"github.com/olekukonko/tablewriter"
)

func main() {
	data := [][]string{
		[]string{"1/1/2014", "Domain name", "2233", "$10.98"},
		[]string{"1/1/2014", "January Hosting", "2233", "$54.95"},
		[]string{"1/4/2014", "February Hosting", "2233", "$51.00"},
		[]string{"1/4/2014", "February Extra Bandwidth", "2233", "$30.00"},
	}

	table := tablewriter.NewWriter(colorable.NewColorableStdout())
	table.SetHeader([]string{"Date", "Description", "CV2", "Amount"})
	table.SetFooter([]string{"", "", "Total", "$146.93"}) // Add Footer
	table.SetBorder(false)                                // Set Border to false

	table.SetHeaderAttributes(tablewriter.Add(tablewriter.Bold, tablewriter.BgGreenColor),
		tablewriter.Add(tablewriter.FgHiRedColor, tablewriter.Bold, tablewriter.BgBlackColor),
		tablewriter.Add(tablewriter.BgRedColor, tablewriter.FgWhiteColor),
		tablewriter.Add(tablewriter.BgCyanColor, tablewriter.FgWhiteColor))

	table.SetColumnAttributes(tablewriter.Add(tablewriter.Bold, tablewriter.FgHiBlackColor),
		tablewriter.Add(tablewriter.Bold, tablewriter.FgHiRedColor),
		tablewriter.Add(tablewriter.Bold, tablewriter.FgHiBlackColor),
		tablewriter.Add(tablewriter.Bold, tablewriter.FgBlackColor))

	table.SetFooterAttributes(tablewriter.Add(), tablewriter.Add(),
		tablewriter.Add(tablewriter.Bold),
		tablewriter.Add(tablewriter.FgHiRedColor))

	table.AppendBulk(data)
	table.Render()
}
```

This change works fine on Windows

![316a6dee8db00394](https://user-images.githubusercontent.com/10111/30220795-da0132f0-94fb-11e7-8e3d-d4fa6f1106e3.png)
