### PR TITLE
Add support for multi-line headers and footers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Generate ASCII table on the fly ...  Installation is simple as
 - Set custom footer support
 - Optional identical cells merging
 - Set custom caption
-
+- Optional reflowing of paragrpahs in multi-line cells.
 
 #### Example   1 - Basic
 ```go
@@ -272,8 +272,6 @@ Movie ratings.
 - ~~Support for `SetFooter`~~  - `done`
 - ~~Support for `SetBorder`~~  - `done`
 - ~~Support table with uneven rows~~ - `done`
-- Support custom alignment
+- ~~Support custom alignment~~
 - General Improvement & Optimisation
 - `NewHTML` Parse table from HTML
-
-

--- a/util.go
+++ b/util.go
@@ -33,9 +33,15 @@ func ConditionString(cond bool, valid, inValid string) string {
 // Format Table Header
 // Replace _ , . and spaces
 func Title(name string) string {
+	origLen := len(name)
 	name = strings.Replace(name, "_", " ", -1)
 	name = strings.Replace(name, ".", " ", -1)
 	name = strings.TrimSpace(name)
+	if len(name) == 0 && origLen > 0 {
+		// Keep at least one character. This is important to preserve
+		// empty lines in multi-line headers/footers.
+		name = " "
+	}
 	return strings.ToUpper(name)
 }
 

--- a/wrap.go
+++ b/wrap.go
@@ -95,10 +95,5 @@ func WrapWords(words []string, spc, lim, pen int) [][]string {
 
 // getLines decomposes a multiline string into a slice of strings.
 func getLines(s string) []string {
-	var lines []string
-
-	for _, line := range strings.Split(s, nl) {
-		lines = append(lines, line)
-	}
-	return lines
+	return strings.Split(s, nl)
 }


### PR DESCRIPTION
See the new test `Example_autowrap()` in `table_test.go` for details.

Also add a new option "reflow during auto wrap"
(`SetReflowDuringAutoWrap()`), which when enabled merges all the lines
in a multi-line cell together before to wrapping, and when disabled
causes paragraphs in a multi-line cell to be cleanly separated.

The default is true to preserve the previous behavior in existing
code.

Needed for https://github.com/cockroachdb/cockroach/pull/19306.