### PR TITLE
Add ClearHeaders

### DIFF
--- a/table.go
+++ b/table.go
@@ -317,6 +317,13 @@ func (t *Table) ClearRows() {
 // ClearHeaders removes all the table's headers.
 func (t *Table) ClearHeaders() {
 	t.headers = t.headers[0:0]
+
+	// resets the headers columns.
+	if len(t.cs) > 0 {
+		for k := range t.cs {
+			delete(t.cs, k)
+		}
+	}
 }
 
 // Clear footer

--- a/table.go
+++ b/table.go
@@ -318,7 +318,7 @@ func (t *Table) ClearRows() {
 func (t *Table) ClearHeaders() {
 	t.headers = t.headers[0:0]
 
-	// resets the headers columns.
+	// reset the column separators, otherwise we will have empty headers if the length of the new headers is smaller than the current one.
 	if len(t.cs) > 0 {
 		for k := range t.cs {
 			delete(t.cs, k)

--- a/table.go
+++ b/table.go
@@ -314,6 +314,11 @@ func (t *Table) ClearRows() {
 	t.lines = [][][]string{}
 }
 
+// ClearHeaders removes all the table's headers.
+func (t *Table) ClearHeaders() {
+	t.headers = t.headers[0:0]
+}
+
 // Clear footer
 func (t *Table) ClearFooter() {
 	t.footers = [][]string{}


### PR DESCRIPTION
Hello @olekukonko , I'm using this library to create something that I find very useful and I'm reusing a the table instance for performance optimizations, unfortunately this library don't have a `ClearHeaders` similar to `ClearRows` and `headers` field is not exported, so there was no way to reset the headers so far, I added a small piece of code to arrange that. It's tested and worked. Thank you a lot, you did great job here!