### PR TITLE
Detect with a large number of words are in a cell, fallback to faster wrapping algorithm

### DIFF
--- a/wrap.go
+++ b/wrap.go
@@ -11,6 +11,8 @@ import (
 	"math"
 	"strings"
 
+	"github.com/bbrks/wrap"
+
 	"github.com/mattn/go-runewidth"
 )
 
@@ -21,10 +23,16 @@ var (
 
 const defaultPenalty = 1e5
 
+const maxWordsToUseNiceAlgo = 500
+
 // Wrap wraps s into a paragraph of lines of length lim, with minimal
 // raggedness.
 func WrapString(s string, lim int) ([]string, int) {
 	words := strings.Split(strings.Replace(s, nl, sp, -1), sp)
+	if len(words) > maxWordsToUseNiceAlgo {
+		rv := wrap.Wrap(s, lim)
+		return strings.Split(rv, nl), lim
+	}
 	var lines []string
 	max := 0
 	for _, v := range words {
@@ -50,6 +58,9 @@ func WrapString(s string, lim int) ([]string, int) {
 // difference of the length of the line and lim. Too-long lines (which only
 // happen when a single word is longer than lim units) have pen penalty units
 // added to the error.
+//
+// Note this function uses both n-squared memory and runtime, so do not call with
+// a long list of words.
 func WrapWords(words []string, spc, lim, pen int) [][]string {
 	n := len(words)
 


### PR DESCRIPTION
We've been happily using `github.com/olekukonko/tablewriter` for some time to display tables of results from arbitrary database queries.

We recently noticed that our server process was crashing due to out of memory errors even when the data returned from the database was tiny.

We eventually tracked it down to the implementation of `WrapWords()` which does some N^2 memory allocation and runtime performance.

We've written this small patch to fallback to a more performant word wrapping library call when the number of words to be wrapped exceeds an arbitrary threshold.

This includes a test (which you should run with and without the patch to judge the impact).

Ironically the library that it falls back to has a single issue open to [Implement raggedness-aware algorithm](https://github.com/bbrks/wrap/issues/2) so perhaps there's a good opportunity to collaborate there?