### PR TITLE
nitpick: use correct rune in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ table.SetRowLine(true)         // Enable row line
 
 // Change table lines
 table.SetCenterSeparator("*")
-table.SetColumnSeparator("‡")
+table.SetColumnSeparator("╪")
 table.SetRowSeparator("-")
 
 table.SetAlignment(tablewriter.ALIGN_LEFT)


### PR DESCRIPTION
This PR changes the README to use the correct rune in the code (the one that matches the rendered output).

Cheers