### PR TITLE
[propose] Allow better customization of individual chars

### DIFF
--- a/separators.go
+++ b/separators.go
@@ -1,0 +1,139 @@
+package tablewriter
+
+const (
+	CENTER  = "+"
+	ROW     = "-"
+	COLUMN  = "|"
+	SPACE   = " "
+	NEWLINE = "\n"
+)
+
+type SeparatorRow struct {
+	Line  string
+	Left  string
+	Mid   string
+	Right string
+}
+
+type SeparatorDataRow struct {
+	Left  string
+	Mid   string
+	Right string
+}
+
+type Separators struct {
+	Top    SeparatorRow
+	Bottom SeparatorRow
+	Middle SeparatorRow
+	Data   SeparatorDataRow
+}
+
+var defaultTheme = Separators{
+	Top: SeparatorRow{
+		Line:  ROW,
+		Left:  CENTER,
+		Right: CENTER,
+		Mid:   CENTER,
+	},
+	Bottom: SeparatorRow{
+		Line:  ROW,
+		Left:  CENTER,
+		Right: CENTER,
+		Mid:   CENTER,
+	},
+	Middle: SeparatorRow{
+		Line:  ROW,
+		Left:  CENTER,
+		Right: CENTER,
+		Mid:   CENTER,
+	},
+	Data: SeparatorDataRow{
+		Left:  COLUMN,
+		Right: COLUMN,
+		Mid:   COLUMN,
+	},
+}
+
+var cliTableTheme = Separators{
+	Top: SeparatorRow{
+		Line:  "─",
+		Left:  "┌",
+		Right: "┐",
+		Mid:   "┬",
+	},
+	Bottom: SeparatorRow{
+		Line:  "─",
+		Left:  "└",
+		Right: "┘",
+		Mid:   "┴",
+	},
+	Middle: SeparatorRow{
+		Line:  "─",
+		Left:  "├",
+		Right: "┤",
+		Mid:   "┼",
+	},
+	Data: SeparatorDataRow{
+		Left:  "│",
+		Right: "│",
+		Mid:   "│",
+	},
+}
+
+var cliTableDoubleTheme = Separators{
+	Top: SeparatorRow{
+		Line:  "═",
+		Left:  "╔",
+		Right: "╗",
+		Mid:   "╤",
+	},
+	Bottom: SeparatorRow{
+		Line:  "═",
+		Left:  "╚",
+		Right: "╝",
+		Mid:   "╧",
+	},
+	Middle: SeparatorRow{
+		Line:  "─",
+		Left:  "╟",
+		Right: "╢",
+		Mid:   "┼",
+	},
+	Data: SeparatorDataRow{
+		Left:  "║",
+		Right: "║",
+		Mid:   "│",
+	},
+}
+
+// Themes defines some out-of-the box themes
+var Themes = struct {
+	CliTable       Separators
+	CliTableDouble Separators
+	Default        Separators
+}{
+	CliTable:       cliTableTheme,
+	CliTableDouble: cliTableDoubleTheme,
+	Default:        defaultTheme,
+}
+
+type linePosition int
+
+const (
+	topLine    linePosition = 0
+	middleLine linePosition = 1
+	bottomLine linePosition = 2
+	dataLine   linePosition = 3
+)
+
+func (s *Separators) getSeparatorsRow(lp linePosition) SeparatorRow {
+	switch lp {
+	case topLine:
+		return s.Top
+	case bottomLine:
+		return s.Bottom
+	case middleLine:
+		return s.Middle
+	}
+	return s.Middle
+}

--- a/table_test.go
+++ b/table_test.go
@@ -131,7 +131,7 @@ func TestCSVInfo(t *testing.T) {
 
 	got := buf.String()
 	want := `   FIELD   |     TYPE     | NULL | KEY | DEFAULT |     EXTRA       
-+----------+--------------+------+-----+---------+----------------+
+-----------+--------------+------+-----+---------+-----------------
   user_id  | smallint(5)  | NO   | PRI | NULL    | auto_increment  
   username | varchar(10)  | NO   |     | NULL    |                 
   password | varchar(100) | NO   |     | NULL    |                 
@@ -167,6 +167,77 @@ func TestCSVSeparator(t *testing.T) {
 	checkEqual(t, buf.String(), want, "CSV info failed")
 }
 
+func TestCliTableStyle(t *testing.T) {
+	buf := &bytes.Buffer{}
+	table, err := NewCSV(buf, "testdata/test.csv", true)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	table.SetSeparators(Themes.CliTable)
+	// table.SetSeparators()
+	table.SetAlignment(ALIGN_LEFT)
+	table.Render()
+
+	want := `┌────────────┬───────────┬─────────┐
+│ FIRST NAME │ LAST NAME │   SSN   │
+├────────────┼───────────┼─────────┤
+│ John       │ Barry     │ 123456  │
+│ Kathy      │ Smith     │ 687987  │
+│ Bob        │ McCornick │ 3979870 │
+└────────────┴───────────┴─────────┘
+`
+
+	checkEqual(t, buf.String(), want, "CliTable theme failed")
+}
+
+func TestCliTableDoubleStyle(t *testing.T) {
+	buf := &bytes.Buffer{}
+	table, err := NewCSV(buf, "testdata/test.csv", true)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	table.SetSeparators(Themes.CliTableDouble)
+	// table.SetSeparators()
+	table.SetAlignment(ALIGN_LEFT)
+	table.Render()
+
+	want := `╔════════════╤═══════════╤═════════╗
+║ FIRST NAME │ LAST NAME │   SSN   ║
+╟────────────┼───────────┼─────────╢
+║ John       │ Barry     │ 123456  ║
+║ Kathy      │ Smith     │ 687987  ║
+║ Bob        │ McCornick │ 3979870 ║
+╚════════════╧═══════════╧═════════╝
+`
+
+	checkEqual(t, buf.String(), want, "CliTableDouble theme failed")
+}
+
+func TestCliTableStyleWithoutBorders(t *testing.T) {
+	buf := &bytes.Buffer{}
+	table, err := NewCSV(buf, "testdata/test.csv", true)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	table.SetSeparators(Themes.CliTable)
+	table.SetBorder(false)
+	// table.SetSeparators()
+	table.SetAlignment(ALIGN_LEFT)
+	table.Render()
+
+	want := `  FIRST NAME │ LAST NAME │   SSN    
+─────────────┼───────────┼──────────
+  John       │ Barry     │ 123456   
+  Kathy      │ Smith     │ 687987   
+  Bob        │ McCornick │ 3979870  
+`
+
+	checkEqual(t, buf.String(), want, "CliTable without border failed")
+}
+
 func TestNoBorder(t *testing.T) {
 	data := [][]string{
 		{"1/1/2014", "Domain name", "2233", "$10.98"},
@@ -187,7 +258,7 @@ func TestNoBorder(t *testing.T) {
 	table.Render()
 
 	want := `    DATE   |       DESCRIPTION        |  CV2  | AMOUNT   
-+----------+--------------------------+-------+---------+
+-----------+--------------------------+-------+----------
   1/1/2014 | Domain name              |  2233 | $10.98   
   1/1/2014 | January Hosting          |  2233 | $54.95   
            |     (empty)              |       |          
@@ -195,7 +266,7 @@ func TestNoBorder(t *testing.T) {
   1/4/2014 | February Hosting         |  2233 | $51.00   
   1/4/2014 | February Extra Bandwidth |  2233 | $30.00   
   1/4/2014 |     (Discount)           |  2233 | -$1.00   
-+----------+--------------------------+-------+---------+
+-----------+--------------------------+-------+----------
                                         TOTAL | $145.93  
                                       +-------+---------+
 `
@@ -395,12 +466,12 @@ func TestPrintCaptionWithFooter(t *testing.T) {
 	table.Render()
 
 	want := `    DATE   |       DESCRIPTION        |  CV2  | AMOUNT   
-+----------+--------------------------+-------+---------+
+-----------+--------------------------+-------+----------
   1/1/2014 | Domain name              |  2233 | $10.98   
   1/1/2014 | January Hosting          |  2233 | $54.95   
   1/4/2014 | February Hosting         |  2233 | $51.00   
   1/4/2014 | February Extra Bandwidth |  2233 | $30.00   
-+----------+--------------------------+-------+---------+
+-----------+--------------------------+-------+----------
                                         TOTAL | $146.93  
                                       +-------+---------+
 This is a very long caption. The text should wrap to the
@@ -713,7 +784,7 @@ func TestPrintLine(t *testing.T) {
 	var buf bytes.Buffer
 	table := NewWriter(&buf)
 	table.SetHeader(header)
-	table.printLine(false)
+	table.printLine(false, topLine)
 	checkEqual(t, buf.String(), want, "line rendering failed")
 }
 
@@ -730,7 +801,7 @@ func TestAnsiStrip(t *testing.T) {
 	var buf bytes.Buffer
 	table := NewWriter(&buf)
 	table.SetHeader(header)
-	table.printLine(false)
+	table.printLine(false, topLine)
 	checkEqual(t, buf.String(), want, "line rendering failed")
 }
 


### PR DESCRIPTION
This change is inspired by node.js's https://github.com/Automattic/cli-table which allows to configure more separator characters to allow the user to use a wider scope of ascii characters.

By default it still render as before and still has the same 3 methods for customizing the characters.

I am introducing a new method called `SetSeparators()` which receives an struct with all separators characters.

I am also exposing `Themes.Default`, `Themes.CliTable`, `Themes.CliTableDouble`.

Example with Themes.Default (or by not setting the separators):

```
+------------+-----------+---------+
| FIRST NAME | LAST NAME |   SSN   |
+------------+-----------+---------+
| John       | Barry     | 123456  |
+------------+-----------+---------+
| Kathy      | Smith     | 687987  |
+------------+-----------+---------+
| Bob        | McCornick | 3979870 |
+------------+-----------+---------+

```

Example with Themes.CliTable

```
┌────────────┬───────────┬─────────┐
│ FIRST NAME │ LAST NAME │   SSN   │
├────────────┼───────────┼─────────┤
│ John       │ Barry     │ 123456  │
│ Kathy      │ Smith     │ 687987  │
│ Bob        │ McCornick │ 3979870 │
└────────────┴───────────┴─────────┘
```

Example with Themes.CliTableDouble

```
╔════════════╤═══════════╤═════════╗
║ FIRST NAME │ LAST NAME │   SSN   ║
╟────────────┼───────────┼─────────╢
║ John       │ Barry     │ 123456  ║
║ Kathy      │ Smith     │ 687987  ║
║ Bob        │ McCornick │ 3979870 ║
╚════════════╧═══════════╧═════════╝
```

Example with `table.SetSeparators(Themes.CliTable)`and `table.SetBorder(false)`:

```
  FIRST NAME │ LAST NAME │   SSN    
─────────────┼───────────┼──────────
  John       │ Barry     │ 123456   
  Kathy      │ Smith     │ 687987   
  Bob        │ McCornick │ 3979870  
```