### PR TITLE
borders: allow customization of corners

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,37 @@ table.Render()
 *------------*-----------*---------*
 ```
 
-#### Example 5 - Markdown Format
+#### Example 5 - More Custom Separators
+
+```go
+table, _ := NewCSV(&buf, "testdata/test.csv", true)
+table.SetColumnSeparator("│")
+table.SetRowSeparator("─")
+// center separator overrides all the corner separators, needs to be first
+table.SetCenterSeparator("┼")
+table.SetTopSeparator("┬")
+table.SetBottomSeparator("┴")
+table.SetLeftSeparator("├")
+table.SetRightSeparator("┤")
+table.SetTopLeftSeparator("┌")
+table.SetTopRightSeparator("┐")
+table.SetBottomLeftSeparator("└")
+table.SetBottomRightSeparator("┘")
+```
+
+##### Output 5
+
+```
+┌────────────┬───────────┬─────────┐
+│ FIRST NAME │ LAST NAME │   SSN   │
+├────────────┼───────────┼─────────┤
+│ John       │ Barry     │  123456 │
+│ Kathy      │ Smith     │  687987 │
+│ Bob        │ McCornick │ 3979870 │
+└────────────┴───────────┴─────────┘
+```
+
+#### Example 6 - Markdown Format
 ```go
 data := [][]string{
 	[]string{"1/1/2014", "Domain name", "2233", "$10.98"},
@@ -152,7 +182,7 @@ table.AppendBulk(data) // Add Bulk Data
 table.Render()
 ```
 
-##### Output 5
+##### Output 6
 ```
 |   DATE   |       DESCRIPTION        | CV2  | AMOUNT |
 |----------|--------------------------|------|--------|
@@ -162,7 +192,7 @@ table.Render()
 | 1/4/2014 | February Extra Bandwidth | 2233 | $30.00 |
 ```
 
-#### Example 6  - Identical cells merging
+#### Example 7  - Identical cells merging
 ```go
 data := [][]string{
   []string{"1/1/2014", "Domain name", "1234", "$10.98"},
@@ -180,7 +210,7 @@ table.AppendBulk(data)
 table.Render()
 ```
 
-##### Output 6
+##### Output 7
 ```
 +----------+--------------------------+-------+---------+
 |   DATE   |       DESCRIPTION        |  CV2  | AMOUNT  |
@@ -198,7 +228,7 @@ table.Render()
 ```
 
 
-#### Table with color
+#### Example 8 - Table with color
 ```go
 data := [][]string{
 	[]string{"1/1/2014", "Domain name", "2233", "$10.98"},
@@ -230,10 +260,10 @@ table.AppendBulk(data)
 table.Render()
 ```
 
-#### Table with color Output
+##### Output 8
 ![Table with Color](https://cloud.githubusercontent.com/assets/6460392/21101956/bbc7b356-c0a1-11e6-9f36-dba694746efc.png)
 
-#### Example 6 - Set table caption
+#### Example 9 - Set table caption
 ```go
 data := [][]string{
     []string{"A", "The Good", "500"},
@@ -254,7 +284,7 @@ table.Render() // Send output
 
 Note: Caption text will wrap with total width of rendered table.
 
-##### Output 6
+##### Output 9
 ```
 +------+-----------------------+--------+
 | NAME |         SIGN          | RATING |

--- a/table_test.go
+++ b/table_test.go
@@ -440,6 +440,92 @@ solved.
 	checkEqual(t, buf.String(), want, "long caption for long example rendering failed")
 }
 
+func TestPrintCornerBorders(t *testing.T) {
+	var buf bytes.Buffer
+	data := [][]string{
+		{"what's up", "the sky", "ok"},
+		{"sup", "the ceiling", "so-so"},
+	}
+
+	table := NewWriter(&buf)
+	table.SetAutoMergeCells(true)
+	table.SetBorders(Border{
+		Left: true,
+		Right: true,
+		Top: true,
+		Bottom: false,
+	})
+	table.SetFooter([]string{"", "", "yeah"})
+	table.SetCenterSeparator("┼")
+	table.SetColumnSeparator("│")
+	table.SetRowSeparator("─")
+	table.SetTopSeparator("┬")
+	table.SetBottomSeparator("┴")
+	table.SetLeftSeparator("├")
+	table.SetRightSeparator("┤")
+	table.SetTopLeftSeparator("┌")
+	table.SetTopRightSeparator("┐")
+	table.SetBottomLeftSeparator("└")
+	table.SetBottomRightSeparator("┘")
+	table.SetHeader([]string{"Question", "Answer", "Comment"})
+
+	for _, v := range data {
+		table.Append(v)
+	}
+	table.Render()
+
+	want := `┌───────────┬─────────────┬─────────┐
+│ QUESTION  │   ANSWER    │ COMMENT │
+├───────────┼─────────────┼─────────┤
+│ what's up │ the sky     │ ok      │
+│ sup       │ the ceiling │ so-so   │
+└───────────┴─────────────┴─────────┘
+│                            YEAH   │
+└───────────┴─────────────┴─────────┘
+`
+	checkEqual(t, buf.String(), want, "corner rendering failed")
+}
+
+func TestPrintCornerBordersWithoutBorders(t *testing.T) {
+	var buf bytes.Buffer
+	data := [][]string{
+		{"what's up", "the sky", "ok", "", "wub wub"},
+		{"sup", "the ceiling", "so-so"},
+	}
+
+	table := NewWriter(&buf)
+	table.SetAutoMergeCells(true)
+	table.SetBorder(false)
+	table.SetFooter([]string{"", "these are nice answers", "yeah", "", "i know right"})
+	table.SetCenterSeparator("┼")
+	table.SetColumnSeparator("│")
+	table.SetRowSeparator("─")
+	table.SetTopSeparator("┬")
+	table.SetBottomSeparator("┴")
+	table.SetLeftSeparator("├")
+	table.SetRightSeparator("┤")
+	table.SetTopLeftSeparator("┌")
+	table.SetTopRightSeparator("┐")
+	table.SetBottomLeftSeparator("└")
+	table.SetBottomRightSeparator("┘")
+	table.SetHeader([]string{"Question", "Answer", "Comment"})
+
+	for _, v := range data {
+		table.Append(v)
+	}
+	table.Render()
+
+	want := `  QUESTION  │         ANSWER         │ COMMENT │  │               
+├───────────┼────────────────────────┼─────────┼──┼──────────────┤
+  what's up │ the sky                │ ok      │  │ wub wub       
+  sup       │ the ceiling            │ so-so    
+└───────────┴────────────────────────┴─────────┴──┴──────────────┘
+              THESE ARE NICE ANSWERS │  YEAH        I KNOW RIGHT  
+            └────────────────────────┴─────────┘  └──────────────┘
+`
+	checkEqual(t, buf.String(), want, "corder rendering failed")
+}
+
 func Example_autowrap() {
 	var multiline = `A multiline
 string with some lines being really long.`
@@ -713,7 +799,7 @@ func TestPrintLine(t *testing.T) {
 	var buf bytes.Buffer
 	table := NewWriter(&buf)
 	table.SetHeader(header)
-	table.printLine(false)
+	table.printLine(false, false, false)
 	checkEqual(t, buf.String(), want, "line rendering failed")
 }
 
@@ -730,7 +816,7 @@ func TestAnsiStrip(t *testing.T) {
 	var buf bytes.Buffer
 	table := NewWriter(&buf)
 	table.SetHeader(header)
-	table.printLine(false)
+	table.printLine(false, false, false)
 	checkEqual(t, buf.String(), want, "line rendering failed")
 }
 


### PR DESCRIPTION
I guess this is similar to #115, although slightly lower-level. Current rendering behavior is unchanged (no existing tests were changed). This allows using unicode corner characters for nicer rendering.