### PR TITLE
Allow for Color formating on Merged Cells

### DIFF
--- a/table.go
+++ b/table.go
@@ -706,6 +706,11 @@ func (t *Table) printRowMergeCells(writer io.Writer, columns [][]string, rowIdx 
 	// Pad Each Height
 	pads := []int{}
 
+	// Checking for ANSI escape sequences for columns
+	is_esc_seq := false
+	if len(t.columnsParams) > 0 {
+		is_esc_seq = true
+	}
 	for i, line := range columns {
 		length := len(line)
 		pad := max - length
@@ -726,6 +731,11 @@ func (t *Table) printRowMergeCells(writer io.Writer, columns [][]string, rowIdx 
 			fmt.Fprintf(writer, SPACE)
 
 			str := columns[y][x]
+
+			// Embedding escape sequence with column value
+			if is_esc_seq {
+				str = format(str, t.columnsParams[y])
+			}
 
 			if t.autoMergeCells {
 				//Store the full line to merge mutli-lines cells


### PR DESCRIPTION
@knz @mattn @hasit 

# What

This makes it so that `printRowMergeCells` uses the same code that `printRow` does https://github.com/olekukonko/tablewriter/blob/master/table.go#L611-L638 in order to allow Merged Cell Print to also use the `SetColumnColor` formatting.

# Why

Right now you dont get any colors when you combine merging cells and SetColumnColor

```
table.SetAutoMergeCells(true)

table.SetColumnColor(tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiRedColor},
   tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiBlackColor},
   tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiBlackColor},
   tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiBlackColor})
```

# Testing

Build a merged celled table and render it with current master, you will see that SetColumnColors does nothing for the columns, while the SetHeaderColor *does* work

![image](https://user-images.githubusercontent.com/9064687/52750829-543a2f80-2fbb-11e9-8c32-ebfba5e766f6.png)

With this change, you can see that the merged printed rows now take the correct color

![image](https://user-images.githubusercontent.com/9064687/52750862-5f8d5b00-2fbb-11e9-9e21-0f6cc14c3a83.png)

Not sure who I should @ mention on this, but I did the top 3 contributors if thats ok :)