### PR TITLE
SetColumnAlignment accepts string as alignment specifier

### DIFF
--- a/table.go
+++ b/table.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"reflect"
 	"regexp"
 	"strings"
 )
@@ -225,8 +226,31 @@ func (t *Table) SetAlignment(align int) {
 	t.align = align
 }
 
-func (t *Table) SetColumnAlignment(keys []int) {
-	for _, v := range keys {
+func (t *Table) SetColumnAlignment(keys interface{}) {
+	aligns := []int{}
+
+	ks := reflect.ValueOf(keys)
+	if ks.Kind() == reflect.String {
+		s := keys.(string)
+		for i := 0; i < len(s); i++ {
+			var a int
+			switch s[i] {
+			case '<':
+				a = ALIGN_LEFT
+			case '>':
+				a = ALIGN_RIGHT
+			case '|':
+				a = ALIGN_CENTER
+			default:
+				a = ALIGN_DEFAULT
+			}
+			aligns = append(aligns, a)
+		}
+	} else {
+		aligns = keys.([]int)
+	}
+
+	for _, v := range aligns {
 		switch v {
 		case ALIGN_CENTER:
 			break

--- a/table_test.go
+++ b/table_test.go
@@ -1082,6 +1082,36 @@ func TestCustomAlign(t *testing.T) {
 	checkEqual(t, buf.String(), want)
 }
 
+func TestCustomAlignString(t *testing.T) {
+	var (
+		buf    = &bytes.Buffer{}
+		table  = NewWriter(buf)
+		header = []string{"AAA", "BBB", "CCC"}
+		data   = [][]string{
+			{"a", "b", "c"},
+			{"1", "2", "3"},
+		}
+		footer = []string{"a", "b", "cccc"}
+		want   = `+-----+-----+-------+
+| AAA | BBB |  CCC  |
++-----+-----+-------+
+| a   |  b  |     c |
+| 1   |  2  |     3 |
++-----+-----+-------+
+|  A  |  B  | CCCC  |
++-----+-----+-------+
+`
+	)
+	table.SetHeader(header)
+	table.SetFooter(footer)
+	table.AppendBulk(data)
+	table.SetColMinWidth(2, 5)
+	table.SetColumnAlignment("<|>")
+	table.Render()
+
+	checkEqual(t, buf.String(), want)
+}
+
 func TestTitle(t *testing.T) {
 	ts := []struct {
 		text string


### PR DESCRIPTION
I'd like to make it more easier to use: code less, do the same:)

`table.SetColumnAlignment("<|>")` is same as `table.SetColumnAlignment([]int{ALIGN_LEFT, ALIGN_CENTER, ALIGN_RIGHT})`