### PR TITLE
Fix bug: not auto-merged if the number of lines in other columns is different

### DIFF
--- a/table.go
+++ b/table.go
@@ -766,7 +766,7 @@ func (t *Table) printRowMergeCells(writer io.Writer, columns [][]string, rowIdx 
 
 			if t.autoMergeCells {
 				//Store the full line to merge mutli-lines cells
-				fullLine := strings.Join(columns[y], " ")
+				fullLine := strings.TrimRight(strings.Join(columns[y], " "), " ")
 				if len(previousLine) > y && fullLine == previousLine[y] && fullLine != "" {
 					// If this cell is identical to the one above but not empty, we don't display the border and keep the cell empty.
 					displayCellBorder = append(displayCellBorder, false)
@@ -804,7 +804,7 @@ func (t *Table) printRowMergeCells(writer io.Writer, columns [][]string, rowIdx 
 	//The new previous line is the current one
 	previousLine = make([]string, total)
 	for y := 0; y < total; y++ {
-		previousLine[y] = strings.Join(columns[y], " ") //Store the full line for multi-lines cells
+		previousLine[y] = strings.TrimRight(strings.Join(columns[y], " ")," ") //Store the full line for multi-lines cells
 	}
 	//Returns the newly added line and wether or not a border should be displayed above.
 	return previousLine, displayCellBorder

--- a/table_test.go
+++ b/table_test.go
@@ -841,14 +841,40 @@ func TestAutoMergeRows(t *testing.T) {
 | NAME |              SIGN              | RATING |
 +------+--------------------------------+--------+
 | A    | The Good                       |    500 |
-+------+--------------------------------+--------+
-| A    | The Very very very very very   |    288 |
++      +--------------------------------+--------+
+|      | The Very very very very very   |    288 |
 |      | Bad Man                        |        |
 +------+                                +--------+
 | B    |                                |    120 |
 |      |                                |        |
 +------+--------------------------------+--------+
 | C    | The Very very Bad Man          |    200 |
++------+--------------------------------+--------+
+`
+	checkEqual(t, buf.String(), want)
+
+	buf.Reset()
+	table = NewWriter(&buf)
+	table.SetHeader([]string{"Name", "Sign", "Rating"})
+
+	dataWithlongText2 := [][]string{
+		{"A", "The Good", "500"},
+		{"A", "The Very very very very very Bad Man", "288"},
+		{"B", "The Very very Bad Man", "120"},
+	}
+	table.AppendBulk(dataWithlongText2)
+	table.SetAutoMergeCells(true)
+	table.SetRowLine(true)
+	table.Render()
+	want = `+------+--------------------------------+--------+
+| NAME |              SIGN              | RATING |
++------+--------------------------------+--------+
+| A    | The Good                       |    500 |
++      +--------------------------------+--------+
+|      | The Very very very very very   |    288 |
+|      | Bad Man                        |        |
++------+--------------------------------+--------+
+| B    | The Very very Bad Man          |    120 |
 +------+--------------------------------+--------+
 `
 	checkEqual(t, buf.String(), want)


### PR DESCRIPTION
## Sample code:
```
package main
import (
	"os"

	"github.com/olekukonko/tablewriter"
)

func main() {
	data := [][]string{
		[]string{"A", "The Good", "500"},
		[]string{"A", "The Very very very very very Bad Man", "288"},
		[]string{"C", "The Ugly", "120"},
		[]string{"D", "The Gopher", "800"},
	}

	table := tablewriter.NewWriter(os.Stdout)
	table.SetHeader([]string{"Name", "Sign", "Rating"})
	table.SetAutoMergeCells(true)
	table.SetRowLine(true)

	for _, v := range data {
		table.Append(v)
	}
	table.Render()
}
```

## Expected
```
+------+--------------------------------+--------+
| NAME |              SIGN              | RATING |
+------+--------------------------------+--------+
| A    | The Good                       |    500 |
+      +--------------------------------+--------+
|      | The Very very very very very   |    288 |
|      | Bad Man                        |        |
+------+--------------------------------+--------+
| C    | The Ugly                       |    120 |
+------+--------------------------------+--------+
| D    | The Gopher                     |    800 |
+------+--------------------------------+--------+
```

## Actual
```
+------+--------------------------------+--------+
| NAME |              SIGN              | RATING |
+------+--------------------------------+--------+
| A    | The Good                       |    500 |
+------+--------------------------------+--------+
| A    | The Very very very very very   |    288 |
|      | Bad Man                        |        |
+------+--------------------------------+--------+
| C    | The Ugly                       |    120 |
+------+--------------------------------+--------+
| D    | The Gopher                     |    800 |
+------+--------------------------------+--------+
```

The reason for this bug is that the number of lines in the SIGN column is different.
1st line: 1 line
```
The Good 
```

2nd line: 2 lines
```
The Very very very very very
Bad Man
``` 

Of course, if the number of lines is the same, it works.

```
+------+----------------------------+--------+
| NAME |            SIGN            | RATING |
+------+----------------------------+--------+
| A    | The Good                   |    500 |
+      +----------------------------+--------+
|      | The Very very very Bad Man |    288 |
+------+----------------------------+--------+
| C    | The Ugly                   |    120 |
+------+----------------------------+--------+
| D    | The Gopher                 |    800 |
+------+----------------------------+--------+
```
