### PR TITLE
Add Color For Individual Cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ table.Render()
 
 #### Table Cells with Color
 
+Individual Cell Colors from `func Rich` take precedence over Column Colors
+
 ```go
 data := [][]string{
 	[]string{"Test1Merge", "HelloCol2 - 1", "HelloCol3 - 1", "HelloCol4 - 1"},

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ data := [][]string{
 	[]string{"Test2Merge", "HelloCol2 - 7", "HelloCol3 - 7", "HelloCol4 - 7"},
 	[]string{"Test3Merge", "HelloCol2 - 8", "HelloCol3 - 8", "HelloCol4 - 8"},
 	[]string{"Test3Merge", "HelloCol2 - 9", "HelloCol3 - 9", "HelloCol4 - 9"},
-	[]string{"Test3Merge", "HelloCol2 - 10", "HelloCol3 -10", "HelloCol4 10"},
+	[]string{"Test3Merge", "HelloCol2 - 10", "HelloCol3 -10", "HelloCol4 - 10"},
 }
 
 table := tablewriter.NewWriter(os.Stdout)
@@ -279,7 +279,7 @@ table.Render()
 ```
 
 #### Table cells with color Output
-![Table cells with Color](https://user-images.githubusercontent.com/9064687/56603772-5f6a9680-65ce-11e9-8e4d-8236ded100d0.png)
+![Table cells with Color](https://user-images.githubusercontent.com/9064687/56604451-ee2be300-65cf-11e9-9c7b-10234e4538ff.png)
 
 #### Example 6 - Set table caption
 ```go

--- a/README.md
+++ b/README.md
@@ -259,11 +259,6 @@ table.SetHeaderColor(tablewriter.Colors{tablewriter.Bold, tablewriter.BgGreenCol
 	tablewriter.Colors{tablewriter.BgRedColor, tablewriter.FgWhiteColor},
 	tablewriter.Colors{tablewriter.BgCyanColor, tablewriter.FgWhiteColor})
 
-table.SetCellColor(1, 3, tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiBlueColor})
-table.SetCellColor(0, 0, tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiYellowColor})
-table.SetCellColor(2, 1, tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiGreenColor})
-table.SetCellColor(3, 9, tablewriter.Colors{tablewriter.Bold, tablewriter.BgGreenColor})
-
 table.SetColumnColor(tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiBlackColor},
 	tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiRedColor},
 	tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiBlackColor},
@@ -273,13 +268,24 @@ table.SetFooterColor(tablewriter.Colors{}, tablewriter.Colors{},
 	tablewriter.Colors{tablewriter.Bold},
 	tablewriter.Colors{tablewriter.FgHiRedColor})
 
-table.AppendBulk(data)
+colorData1 := []string{"TestCOLOR1Merge", "HelloCol2 - COLOR1", "HelloCol3 - COLOR1", "HelloCol4 - COLOR1"}
+colorData2 := []string{"TestCOLOR2Merge", "HelloCol2 - COLOR2", "HelloCol3 - COLOR2", "HelloCol4 - COLOR2"}
+
+for i, row := range data {
+	if i == 4 {
+		table.Rich(colorData1, []tablewriter.Colors{tablewriter.Colors{}, tablewriter.Colors{tablewriter.Normal, tablewriter.FgCyanColor}, tablewriter.Colors{tablewriter.Bold, tablewriter.FgWhiteColor}, tablewriter.Colors{}})
+		table.Rich(colorData2, []tablewriter.Colors{tablewriter.Colors{tablewriter.Normal, tablewriter.FgMagentaColor}, tablewriter.Colors{}, tablewriter.Colors{tablewriter.Bold, tablewriter.BgRedColor}, tablewriter.Colors{tablewriter.FgHiGreenColor, tablewriter.Italic, tablewriter.BgHiCyanColor}})
+	}
+	table.Append(row)
+}
+
 table.SetAutoMergeCells(true)
 table.Render()
+
 ```
 
 #### Table cells with color Output
-![Table cells with Color](https://user-images.githubusercontent.com/9064687/56604451-ee2be300-65cf-11e9-9c7b-10234e4538ff.png)
+![Table cells with Color](https://user-images.githubusercontent.com/9064687/63969376-bcd88d80-ca6f-11e9-9466-c3d954700b25.png)
 
 #### Example 6 - Set table caption
 ```go

--- a/README.md
+++ b/README.md
@@ -233,6 +233,54 @@ table.Render()
 #### Table with color Output
 ![Table with Color](https://cloud.githubusercontent.com/assets/6460392/21101956/bbc7b356-c0a1-11e6-9f36-dba694746efc.png)
 
+#### Table Cells with Color
+
+```go
+data := [][]string{
+	[]string{"Test1Merge", "HelloCol2 - 1", "HelloCol3 - 1", "HelloCol4 - 1"},
+	[]string{"Test1Merge", "HelloCol2 - 2", "HelloCol3 - 2", "HelloCol4 - 2"},
+	[]string{"Test1Merge", "HelloCol2 - 3", "HelloCol3 - 3", "HelloCol4 - 3"},
+	[]string{"Test2Merge", "HelloCol2 - 4", "HelloCol3 - 4", "HelloCol4 - 4"},
+	[]string{"Test2Merge", "HelloCol2 - 5", "HelloCol3 - 5", "HelloCol4 - 5"},
+	[]string{"Test2Merge", "HelloCol2 - 6", "HelloCol3 - 6", "HelloCol4 - 6"},
+	[]string{"Test2Merge", "HelloCol2 - 7", "HelloCol3 - 7", "HelloCol4 - 7"},
+	[]string{"Test3Merge", "HelloCol2 - 8", "HelloCol3 - 8", "HelloCol4 - 8"},
+	[]string{"Test3Merge", "HelloCol2 - 9", "HelloCol3 - 9", "HelloCol4 - 9"},
+	[]string{"Test3Merge", "HelloCol2 - 10", "HelloCol3 -10", "HelloCol4 10"},
+}
+
+table := tablewriter.NewWriter(os.Stdout)
+table.SetHeader([]string{"Col1", "Col2", "Col3", "Col4"})
+table.SetFooter([]string{"", "", "Footer3", "Footer4"})
+table.SetBorder(false)
+
+table.SetHeaderColor(tablewriter.Colors{tablewriter.Bold, tablewriter.BgGreenColor},
+	tablewriter.Colors{tablewriter.FgHiRedColor, tablewriter.Bold, tablewriter.BgBlackColor},
+	tablewriter.Colors{tablewriter.BgRedColor, tablewriter.FgWhiteColor},
+	tablewriter.Colors{tablewriter.BgCyanColor, tablewriter.FgWhiteColor})
+
+table.SetCellColor(1, 3, tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiBlueColor})
+table.SetCellColor(0, 0, tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiYellowColor})
+table.SetCellColor(2, 1, tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiGreenColor})
+table.SetCellColor(3, 9, tablewriter.Colors{tablewriter.Bold, tablewriter.BgGreenColor})
+
+table.SetColumnColor(tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiBlackColor},
+	tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiRedColor},
+	tablewriter.Colors{tablewriter.Bold, tablewriter.FgHiBlackColor},
+	tablewriter.Colors{tablewriter.Bold, tablewriter.FgBlackColor})
+
+table.SetFooterColor(tablewriter.Colors{}, tablewriter.Colors{},
+	tablewriter.Colors{tablewriter.Bold},
+	tablewriter.Colors{tablewriter.FgHiRedColor})
+
+table.AppendBulk(data)
+table.SetAutoMergeCells(true)
+table.Render()
+```
+
+#### Table cells with color Output
+![Table cells with Color](https://user-images.githubusercontent.com/9064687/56603772-5f6a9680-65ce-11e9-8e4d-8236ded100d0.png)
+
 #### Example 6 - Set table caption
 ```go
 data := [][]string{

--- a/table.go
+++ b/table.go
@@ -76,7 +76,7 @@ type Table struct {
 	borders        Border
 	colSize        int
 	headerParams   []string
-	cellParams     [][]string
+	cellParams     []CellColor
 	columnsParams  []string
 	footerParams   []string
 	columnsAlign   []int
@@ -113,6 +113,7 @@ func NewWriter(writer io.Writer) *Table {
 		borders:       Border{Left: true, Right: true, Bottom: true, Top: true},
 		colSize:       -1,
 		headerParams:  []string{},
+		cellParams:    []CellColor{},
 		columnsParams: []string{},
 		footerParams:  []string{},
 		columnsAlign:  []int{}}
@@ -637,7 +638,7 @@ func (t *Table) printRow(columns [][]string, rowIdx int) {
 
 	// Checking for ANSI escape sequences for columns
 	is_esc_seq := false
-	if len(t.columnsParams) > 0 {
+	if len(t.columnsParams) > 0 || len(t.cellParams) > 0 {
 		is_esc_seq = true
 	}
 	t.fillAlignment(total)
@@ -662,8 +663,8 @@ func (t *Table) printRow(columns [][]string, rowIdx int) {
 
 			// Embedding escape sequence with column value
 			if is_esc_seq {
-				if t.cellParams[x][y] != "" {
-					str = format(str, t.cellParams[x][y])
+				if val := t.getColorForCell(y, x+rowIdx); val != "" {
+					str = format(str, val)
 				} else {
 					str = format(str, t.columnsParams[y])
 				}
@@ -740,7 +741,7 @@ func (t *Table) printRowMergeCells(writer io.Writer, columns [][]string, rowIdx 
 
 	// Checking for ANSI escape sequences for columns
 	is_esc_seq := false
-	if len(t.columnsParams) > 0 {
+	if len(t.columnsParams) > 0 || len(t.cellParams) > 0 {
 		is_esc_seq = true
 	}
 	for i, line := range columns {
@@ -766,8 +767,8 @@ func (t *Table) printRowMergeCells(writer io.Writer, columns [][]string, rowIdx 
 
 			// Embedding escape sequence with column value
 			if is_esc_seq {
-				if t.cellParams[x][y] != "" {
-					str = format(str, t.cellParams[x][y])
+				if val := t.getColorForCell(y, x+rowIdx); val != "" {
+					str = format(str, val)
 				} else {
 					str = format(str, t.columnsParams[y])
 				}

--- a/table.go
+++ b/table.go
@@ -298,6 +298,28 @@ func (t *Table) Append(row []string) {
 	t.lines = append(t.lines, line)
 }
 
+// Append row to table with color attributes
+func (t *Table) Rich(row []string, colors []Colors) {
+	rowSize := len(t.headers)
+	if rowSize > t.colSize {
+		t.colSize = rowSize
+	}
+
+	n := len(t.lines)
+	line := [][]string{}
+	for i, v := range row {
+
+		// Detect string  width
+		// Detect String height
+		// Break strings into words
+		out := t.parseDimension(v, i, n)
+
+		// Append broken words
+		line = append(line, out)
+	}
+	t.lines = append(t.lines, line)
+}
+
 // Allow Support for Bulk Append
 // Eliminates repeated for loops
 func (t *Table) AppendBulk(rows [][]string) {
@@ -638,7 +660,7 @@ func (t *Table) printRow(columns [][]string, rowIdx int) {
 
 	// Checking for ANSI escape sequences for columns
 	is_esc_seq := false
-	if len(t.columnsParams) > 0 || len(t.cellParams) > 0 {
+	if len(t.columnsParams) > 0 {
 		is_esc_seq = true
 	}
 	t.fillAlignment(total)
@@ -663,11 +685,7 @@ func (t *Table) printRow(columns [][]string, rowIdx int) {
 
 			// Embedding escape sequence with column value
 			if is_esc_seq {
-				if val := t.getColorForCell(y, x+rowIdx); val != "" {
-					str = format(str, val)
-				} else if len(t.columnsParams) > y {
-					str = format(str, t.columnsParams[y])
-				}
+				str = format(str, t.columnsParams[y])
 			}
 
 			// This would print alignment
@@ -741,7 +759,7 @@ func (t *Table) printRowMergeCells(writer io.Writer, columns [][]string, rowIdx 
 
 	// Checking for ANSI escape sequences for columns
 	is_esc_seq := false
-	if len(t.columnsParams) > 0 || len(t.cellParams) > 0 {
+	if len(t.columnsParams) > 0 {
 		is_esc_seq = true
 	}
 	for i, line := range columns {
@@ -767,11 +785,7 @@ func (t *Table) printRowMergeCells(writer io.Writer, columns [][]string, rowIdx 
 
 			// Embedding escape sequence with column value
 			if is_esc_seq {
-				if val := t.getColorForCell(y, x+rowIdx); val != "" {
-					str = format(str, val)
-				} else if len(t.columnsParams) > y {
-					str = format(str, t.columnsParams[y])
-				}
+				str = format(str, t.columnsParams[y])
 			}
 
 			if t.autoMergeCells {

--- a/table.go
+++ b/table.go
@@ -665,7 +665,7 @@ func (t *Table) printRow(columns [][]string, rowIdx int) {
 			if is_esc_seq {
 				if val := t.getColorForCell(y, x+rowIdx); val != "" {
 					str = format(str, val)
-				} else {
+				} else if len(t.columnsParams) > y {
 					str = format(str, t.columnsParams[y])
 				}
 			}
@@ -769,7 +769,7 @@ func (t *Table) printRowMergeCells(writer io.Writer, columns [][]string, rowIdx 
 			if is_esc_seq {
 				if val := t.getColorForCell(y, x+rowIdx); val != "" {
 					str = format(str, val)
-				} else {
+				} else if len(t.columnsParams) > y {
 					str = format(str, t.columnsParams[y])
 				}
 			}

--- a/table.go
+++ b/table.go
@@ -76,6 +76,7 @@ type Table struct {
 	borders        Border
 	colSize        int
 	headerParams   []string
+	cellParams     [][]string
 	columnsParams  []string
 	footerParams   []string
 	columnsAlign   []int
@@ -661,7 +662,11 @@ func (t *Table) printRow(columns [][]string, rowIdx int) {
 
 			// Embedding escape sequence with column value
 			if is_esc_seq {
-				str = format(str, t.columnsParams[y])
+				if t.cellParams[x][y] != "" {
+					str = format(str, t.cellParams[x][y])
+				} else {
+					str = format(str, t.columnsParams[y])
+				}
 			}
 
 			// This would print alignment
@@ -761,7 +766,11 @@ func (t *Table) printRowMergeCells(writer io.Writer, columns [][]string, rowIdx 
 
 			// Embedding escape sequence with column value
 			if is_esc_seq {
-				str = format(str, t.columnsParams[y])
+				if t.cellParams[x][y] != "" {
+					str = format(str, t.cellParams[x][y])
+				} else {
+					str = format(str, t.columnsParams[y])
+				}
 			}
 
 			if t.autoMergeCells {

--- a/table.go
+++ b/table.go
@@ -76,7 +76,6 @@ type Table struct {
 	borders        Border
 	colSize        int
 	headerParams   []string
-	cellParams     []CellColor
 	columnsParams  []string
 	footerParams   []string
 	columnsAlign   []int
@@ -113,7 +112,6 @@ func NewWriter(writer io.Writer) *Table {
 		borders:       Border{Left: true, Right: true, Bottom: true, Top: true},
 		colSize:       -1,
 		headerParams:  []string{},
-		cellParams:    []CellColor{},
 		columnsParams: []string{},
 		footerParams:  []string{},
 		columnsAlign:  []int{}}
@@ -313,6 +311,11 @@ func (t *Table) Rich(row []string, colors []Colors) {
 		// Detect String height
 		// Break strings into words
 		out := t.parseDimension(v, i, n)
+
+		if len(colors) > i {
+			color := colors[i]
+			out[0] = format(out[0], color)
+		}
 
 		// Append broken words
 		line = append(line, out)

--- a/table_test.go
+++ b/table_test.go
@@ -196,7 +196,7 @@ func TestNoBorder(t *testing.T) {
   1/4/2014 | February Extra Bandwidth |  2233 | $30.00   
   1/4/2014 |     (Discount)           |  2233 | -$1.00   
 -----------+--------------------------+-------+----------
-                                        TOTAL | $145 93  
+                                        TOTAL | $145.93  
                                       --------+----------
 `
 
@@ -401,7 +401,7 @@ func TestPrintCaptionWithFooter(t *testing.T) {
   1/4/2014 | February Hosting         |  2233 | $51.00   
   1/4/2014 | February Extra Bandwidth |  2233 | $30.00   
 -----------+--------------------------+-------+----------
-                                        TOTAL | $146 93  
+                                        TOTAL | $146.93  
                                       --------+----------
 This is a very long caption. The text should wrap to the
 width of the table.

--- a/table_with_color.go
+++ b/table_with_color.go
@@ -89,6 +89,8 @@ func format(s string, codes interface{}) string {
 		seq = v
 	case []int:
 		seq = makeSequence(v)
+	case Colors:
+		seq = makeSequence(v)
 	default:
 		return s
 	}

--- a/table_with_color.go
+++ b/table_with_color.go
@@ -141,12 +141,6 @@ func (t *Table) SetFooterColor(colors ...Colors) {
 // Column and Rows start at 0
 // This does NOT do anything for header/footers
 func (t *Table) SetCellColor(column, row int, color Colors) {
-	if column < 0 || column > t.colSize-1 {
-		panic(fmt.Sprintf("Column Value: %d is outside column size %d", column, t.colSize-1))
-	} else if row < 0 || row > len(t.lines)-1 {
-		panic(fmt.Sprintf("Row Value: %d is outside row size %d", row, len(t.lines)-1))
-	}
-
 	t.cellParams = append(t.cellParams, CellColor{
 		column: column,
 		row:    row,

--- a/table_with_color.go
+++ b/table_with_color.go
@@ -62,14 +62,6 @@ const (
 
 type Colors []int
 
-// CellColor Color information (ie FgHiBlackColor, FgHiRedColor, etc...)
-// For the column and row position in your table
-type CellColor struct {
-	column int
-	row    int
-	color  string
-}
-
 func startFormat(seq string) string {
 	return fmt.Sprintf("%s[%sm", ESC, seq)
 }
@@ -135,28 +127,6 @@ func (t *Table) SetFooterColor(colors ...Colors) {
 	for i := 0; i < len(colors); i++ {
 		t.footerParams = append(t.footerParams, makeSequence(colors[i]))
 	}
-}
-
-// Adding color for cell (ANSI codes) {
-// Column and Rows start at 0
-// This does NOT do anything for header/footers
-func (t *Table) SetCellColor(column, row int, color Colors) {
-	t.cellParams = append(t.cellParams, CellColor{
-		column: column,
-		row:    row,
-		color:  makeSequence(color),
-	})
-}
-
-// Returns makeSequence version of color by cell indices
-func (t *Table) getColorForCell(column, row int) string {
-	for _, colorInfo := range t.cellParams {
-		if column == colorInfo.column && row == colorInfo.row {
-			return colorInfo.color
-		}
-	}
-
-	return ""
 }
 
 func Color(colors ...int) []int {

--- a/table_with_color.go
+++ b/table_with_color.go
@@ -129,6 +129,16 @@ func (t *Table) SetFooterColor(colors ...Colors) {
 	}
 }
 
+// Adding color for cell (ANSI codes) {
+func (t *Table) SetCellColor(x, y int, color Colors) {
+	if x < 0 || x > t.colSize {
+		panic(fmt.Sprintf("X Value: %d is outside column size %d", x, t.colSize))
+	} else if y < 0 || y > len(t.rows) {
+		panic(fmt.Sprintf("Y Value: %d is outside row size %d", y, len(t.rows)))
+	}
+	t.cellParams[x][y] = makeSequence(color)
+}
+
 func Color(colors ...int) []int {
 	return colors
 }

--- a/table_with_color.go
+++ b/table_with_color.go
@@ -62,6 +62,14 @@ const (
 
 type Colors []int
 
+// CellColor Color information (ie FgHiBlackColor, FgHiRedColor, etc...)
+// For the column and row position in your table
+type CellColor struct {
+	column int
+	row    int
+	color  string
+}
+
 func startFormat(seq string) string {
 	return fmt.Sprintf("%s[%sm", ESC, seq)
 }
@@ -130,13 +138,31 @@ func (t *Table) SetFooterColor(colors ...Colors) {
 }
 
 // Adding color for cell (ANSI codes) {
-func (t *Table) SetCellColor(x, y int, color Colors) {
-	if x < 0 || x > t.colSize {
-		panic(fmt.Sprintf("X Value: %d is outside column size %d", x, t.colSize))
-	} else if y < 0 || y > len(t.rows) {
-		panic(fmt.Sprintf("Y Value: %d is outside row size %d", y, len(t.rows)))
+// Column and Rows start at 0
+// This does NOT do anything for header/footers
+func (t *Table) SetCellColor(column, row int, color Colors) {
+	if column < 0 || column > t.colSize-1 {
+		panic(fmt.Sprintf("Column Value: %d is outside column size %d", column, t.colSize-1))
+	} else if row < 0 || row > len(t.lines)-1 {
+		panic(fmt.Sprintf("Row Value: %d is outside row size %d", row, len(t.lines)-1))
 	}
-	t.cellParams[x][y] = makeSequence(color)
+
+	t.cellParams = append(t.cellParams, CellColor{
+		column: column,
+		row:    row,
+		color:  makeSequence(color),
+	})
+}
+
+// Returns makeSequence version of color by cell indices
+func (t *Table) getColorForCell(column, row int) string {
+	for _, colorInfo := range t.cellParams {
+		if column == colorInfo.column && row == colorInfo.row {
+			return colorInfo.color
+		}
+	}
+
+	return ""
 }
 
 func Color(colors ...int) []int {


### PR DESCRIPTION
@knz @mattn @hasit

# What

This adds a new ability `SetCellColor` to set the Cell Colors individually, while combined with/or without Column Colors.  Cell Colors with take PRIORITY over Column Colors (otherwise it wouldn't really do anything 😸 )

# Why

Currently if you set Column coloring the entire column will be color coded that way.  There are times where it would be really nice if we can maintain the color for the column but allow for individual cells to also to also take a different coloring.  Maybe we have a list of files in a table and we want to color code some of them based on certain status for example.

# Testing

I've tested this a few different ways, i've also added a section to the readme to show how to use these column cells.  The readme has the code for these generated tables.  I also tested what happens if the values of (col,row) passed to SetCellColors are out of range, that isn't an issue because `getColorForCell` just returns an emtpy string that is checked for

* NO COLUMN COLORS WITH CELL COLORS ( NOT MERGED )

![image](https://user-images.githubusercontent.com/9064687/56604147-54fccc80-65cf-11e9-9ff3-c2c5dc03ea1f.png)

* COLUMN COLORS WITH CELL PRIORITY ( NOT MERGED )

![image](https://user-images.githubusercontent.com/9064687/56604167-60e88e80-65cf-11e9-8c4a-0a3d54822d4c.png)

* NO COLUMN COLORS WITH CELL COLORS ( MERGED )

![image](https://user-images.githubusercontent.com/9064687/56604095-3696d100-65cf-11e9-96d6-6e8ab070da47.png)

* COLUMN COLORS WITH CELL PRIORITY ( MERGED )

![image](https://user-images.githubusercontent.com/9064687/56604110-3dbddf00-65cf-11e9-94e5-8dd2c2ba7951.png)
