### PR TITLE
Add option to select for title case for headers

### DIFF
--- a/csv2table/csv2table.go
+++ b/csv2table/csv2table.go
@@ -18,6 +18,7 @@ var (
 	align     = flag.String("a", "none", "Set aligmement with eg. none|left|right|center")
 	pipe      = flag.Bool("p", false, "Suport for Piping from STDIN")
 	border    = flag.Bool("b", true, "Enable / disable table border")
+	casing    = flag.Bool("c", false, "Set header to be title case")
 )
 
 func main() {
@@ -76,6 +77,10 @@ func process(r io.Reader) {
 		table.SetAlignment(tablewriter.ALIGN_CENTER)
 	}
 	table.SetBorder(*border)
+	if *casing {
+		table.SetAutoFormatHeaders(false)
+		table.SetTitleCase(*casing)
+	}
 	table.Render()
 }
 


### PR DESCRIPTION
Users can use a c flag to use the title case instead of Uppercase for the header. **Addressing the issue "Option not to force using upper case" #139**