### PR TITLE
Add SetNoWhiteSpace and SetTablePadding options to have more kubectl like output

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ table.Render()
 #### Table with color Output
 ![Table with Color](https://cloud.githubusercontent.com/assets/6460392/21101956/bbc7b356-c0a1-11e6-9f36-dba694746efc.png)
 
-#### Example 6 - Set table caption
+#### Example 7 - Set table caption
 ```go
 data := [][]string{
     []string{"A", "The Good", "500"},
@@ -254,7 +254,7 @@ table.Render() // Send output
 
 Note: Caption text will wrap with total width of rendered table.
 
-##### Output 6
+##### Output 7
 ```
 +------+-----------------------+--------+
 | NAME |         SIGN          | RATING |
@@ -265,6 +265,36 @@ Note: Caption text will wrap with total width of rendered table.
 |  D   |      The Gopher       |    800 |
 +------+-----------------------+--------+
 Movie ratings.
+```
+
+#### Example 8 - Set KubeFormat option
+```go
+data := [][]string{
+    {"node1.example.com", "Ready", "compute", "1.11"},
+    {"node2.example.com", "Ready", "compute", "1.11"},
+    {"node3.example.com", "Ready", "compute", "1.11"},
+    {"node4.example.com", "NotReady", "compute", "1.11"},
+}
+
+table := tablewriter.NewWriter(os.Stdout)
+table.SetHeader([]string{"Name", "Status", "Role", "Version"})
+table.SetAutoWrapText(false)
+table.SetAutoFormatHeaders(true)
+table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+table.SetAlignment(tablewriter.ALIGN_LEFT)
+table.SetKubePadding("\t") // pad with tabs
+table.SetKubeFormat(true)
+table.AppendBulk(data) // Add Bulk Data
+table.Render()
+```
+
+##### Output 8
+```
+NAME             	STATUS  	ROLE   	VERSION 
+node1.example.com	Ready   	compute	1.11   	
+node2.example.com	Ready   	compute	1.11   	
+node3.example.com	Ready   	compute	1.11   	
+node4.example.com	NotReady	compute	1.11   	
 ```
 
 #### Render table into a string

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Note: Caption text will wrap with total width of rendered table.
 Movie ratings.
 ```
 
-#### Example 8 - Set KubeFormat option
+#### Example 8 - Set NoWhiteSpace and TablePadding option
 ```go
 data := [][]string{
     {"node1.example.com", "Ready", "compute", "1.11"},

--- a/README.md
+++ b/README.md
@@ -280,10 +280,15 @@ table := tablewriter.NewWriter(os.Stdout)
 table.SetHeader([]string{"Name", "Status", "Role", "Version"})
 table.SetAutoWrapText(false)
 table.SetAutoFormatHeaders(true)
-table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
-table.SetAlignment(tablewriter.ALIGN_LEFT)
-table.SetKubePadding("\t") // pad with tabs
-table.SetKubeFormat(true)
+table.SetHeaderAlignment(ALIGN_LEFT)
+table.SetAlignment(ALIGN_LEFT)
+table.SetCenterSeparator("")
+table.SetColumnSeparator("")
+table.SetRowSeparator("")
+table.SetHeaderLine(false)
+table.SetBorder(false)
+table.SetTablePadding("\t") // pad with tabs
+table.SetNoWhiteSpace(true)
 table.AppendBulk(data) // Add Bulk Data
 table.Render()
 ```

--- a/table.go
+++ b/table.go
@@ -72,8 +72,8 @@ type Table struct {
 	newLine        string
 	rowLine        bool
 	autoMergeCells bool
-	kubeFormat     bool
-	kubePadding    string
+	noWhiteSpace   bool
+	tablePadding   string
 	hdrLine        bool
 	borders        Border
 	colSize        int
@@ -227,19 +227,14 @@ func (t *Table) SetAlignment(align int) {
 	t.align = align
 }
 
-// SetKubeFormat is used to format the table to be more like kubectl
-func (t *Table) SetKubeFormat(allow bool) {
-	t.kubeFormat = allow
-	t.pColumn = ""
-	t.pRow = ""
-	t.pCenter = ""
-	t.hdrLine = false
-	t.SetBorders(Border{false, false, false, false})
+// SetNoWhiteSpace is used to format the table to be more like kubectl
+func (t *Table) SetNoWhiteSpace(allow bool) {
+	t.noWhiteSpace = allow
 }
 
-// SetKubePadding is used to disable whitespaces in row start to be more like kubectl
-func (t *Table) SetKubePadding(padding string) {
-	t.kubePadding = padding
+// SetTablePadding is used to disable whitespaces in row start to be more like kubectl
+func (t *Table) SetTablePadding(padding string) {
+	t.tablePadding = padding
 }
 
 func (t *Table) SetColumnAlignment(keys []int) {
@@ -428,7 +423,7 @@ func (t *Table) printHeading() {
 	for x := 0; x < max; x++ {
 		// Check if border is set
 		// Replace with space if not set
-		if !t.kubeFormat {
+		if !t.noWhiteSpace {
 			fmt.Fprint(t.out, ConditionString(t.borders.Left, t.pColumn, SPACE))
 		}
 
@@ -443,11 +438,11 @@ func (t *Table) printHeading() {
 				h = Title(h)
 			}
 			pad := ConditionString((y == end && !t.borders.Left), SPACE, t.pColumn)
-			if t.kubeFormat {
-				pad = ConditionString((y == end && !t.borders.Left), SPACE, t.kubePadding)
+			if t.noWhiteSpace {
+				pad = ConditionString((y == end && !t.borders.Left), SPACE, t.tablePadding)
 			}
 			if is_esc_seq {
-				if !t.kubeFormat {
+				if !t.noWhiteSpace {
 					fmt.Fprintf(t.out, " %s %s",
 						format(padFunc(h, SPACE, v),
 							t.headerParams[y]), pad)
@@ -457,7 +452,7 @@ func (t *Table) printHeading() {
 							t.headerParams[y]), pad)
 				}
 			} else {
-				if !t.kubeFormat {
+				if !t.noWhiteSpace {
 					fmt.Fprintf(t.out, " %s %s",
 						padFunc(h, SPACE, v),
 						pad)
@@ -689,7 +684,7 @@ func (t *Table) printRow(columns [][]string, rowIdx int) {
 		for y := 0; y < total; y++ {
 
 			// Check if border is set
-			if !t.kubeFormat {
+			if !t.noWhiteSpace {
 				fmt.Fprint(t.out, ConditionString((!t.borders.Left && y == 0), SPACE, t.pColumn))
 				fmt.Fprintf(t.out, SPACE)
 			}
@@ -725,15 +720,15 @@ func (t *Table) printRow(columns [][]string, rowIdx int) {
 
 				}
 			}
-			if !t.kubeFormat {
+			if !t.noWhiteSpace {
 				fmt.Fprintf(t.out, SPACE)
 			} else {
-				fmt.Fprintf(t.out, t.kubePadding)
+				fmt.Fprintf(t.out, t.tablePadding)
 			}
 		}
 		// Check if border is set
 		// Replace with space if not set
-		if !t.kubeFormat {
+		if !t.noWhiteSpace {
 			fmt.Fprint(t.out, ConditionString(t.borders.Left, t.pColumn, SPACE))
 		}
 		fmt.Fprint(t.out, t.newLine)

--- a/table.go
+++ b/table.go
@@ -227,12 +227,12 @@ func (t *Table) SetAlignment(align int) {
 	t.align = align
 }
 
-// SetNoWhiteSpace is used to format the table to be more like kubectl
+// Set No White Space
 func (t *Table) SetNoWhiteSpace(allow bool) {
 	t.noWhiteSpace = allow
 }
 
-// SetTablePadding is used to disable whitespaces in row start to be more like kubectl
+// Set Table Padding
 func (t *Table) SetTablePadding(padding string) {
 	t.tablePadding = padding
 }

--- a/table_test.go
+++ b/table_test.go
@@ -1145,3 +1145,33 @@ func TestTitle(t *testing.T) {
 		}
 	}
 }
+
+func TestKubeFormat(t *testing.T) {
+	data := [][]string{
+		{"1/1/2014", "jan_hosting", "2233", "$10.98"},
+		{"1/1/2014", "feb_hosting", "2233", "$54.95"},
+		{"1/4/2014", "feb_extra_bandwidth", "2233", "$51.00"},
+		{"1/4/2014", "mar_hosting", "2233", "$30.00"},
+	}
+
+	var buf bytes.Buffer
+	table := NewWriter(&buf)
+	table.SetHeader([]string{"Date", "Description", "CV2", "Amount"})
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetHeaderAlignment(ALIGN_LEFT)
+	table.SetAlignment(ALIGN_LEFT)
+	table.SetKubePadding("\t") // pad with tabs
+	table.SetKubeFormat(true)
+	table.AppendBulk(data) // Add Bulk Data
+	table.Render()
+
+	want := `DATE    	DESCRIPTION        	CV2 	AMOUNT 
+1/1/2014	jan_hosting        	2233	$10.98	
+1/1/2014	feb_hosting        	2233	$54.95	
+1/4/2014	feb_extra_bandwidth	2233	$51.00	
+1/4/2014	mar_hosting        	2233	$30.00	
+`
+
+	checkEqual(t, buf.String(), want, "kube format rendering failed")
+}

--- a/table_test.go
+++ b/table_test.go
@@ -1161,8 +1161,13 @@ func TestKubeFormat(t *testing.T) {
 	table.SetAutoFormatHeaders(true)
 	table.SetHeaderAlignment(ALIGN_LEFT)
 	table.SetAlignment(ALIGN_LEFT)
-	table.SetKubePadding("\t") // pad with tabs
-	table.SetKubeFormat(true)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
 	table.AppendBulk(data) // Add Bulk Data
 	table.Render()
 


### PR DESCRIPTION
## Description
This adds the ability to output table data much more like kubectl by removing the white space at the start of rows. It also introduces a padding option so you can choose either spaces or tab as the padding between columns

An example has been added to the README, but is posted here for visibility

A test has also been written

## Example
#### ExampleSet KubeFormat option
```go
data := [][]string{
    {"node1.example.com", "Ready", "compute", "1.11"},
    {"node2.example.com", "Ready", "compute", "1.11"},
    {"node3.example.com", "Ready", "compute", "1.11"},
    {"node4.example.com", "NotReady", "compute", "1.11"},
}

table := tablewriter.NewWriter(os.Stdout)
table.SetHeader([]string{"Name", "Status", "Role", "Version"})
table.SetAutoWrapText(false)
table.SetAutoFormatHeaders(true)
table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
table.SetAlignment(tablewriter.ALIGN_LEFT)
table.SetCenterSeparator("")
table.SetColumnSeparator("")
table.SetRowSeparator("")
table.SetHeaderLine(false)
table.SetBorder(false)
table.SetTablePadding("\t") // pad with tabs
table.SetNoWhiteSpace(true)
table.AppendBulk(data) // Add Bulk Data
table.Render()
```

##### Output
```
NAME             	STATUS  	ROLE   	VERSION 
node1.example.com	Ready   	compute	1.11   	
node2.example.com	Ready   	compute	1.11   	
node3.example.com	Ready   	compute	1.11   	
node4.example.com	NotReady	compute	1.11   	
```

## Closes
This PR should close #129 