### PR TITLE
Remove ineffective break statements.

### DIFF
--- a/table.go
+++ b/table.go
@@ -240,12 +240,7 @@ func (t *Table) SetTablePadding(padding string) {
 func (t *Table) SetColumnAlignment(keys []int) {
 	for _, v := range keys {
 		switch v {
-		case ALIGN_CENTER:
-			break
-		case ALIGN_LEFT:
-			break
-		case ALIGN_RIGHT:
-			break
+		case ALIGN_LEFT, ALIGN_CENTER, ALIGN_RIGHT:
 		default:
 			v = ALIGN_DEFAULT
 		}


### PR DESCRIPTION
https://staticcheck.io/docs/checks#SA4011

These breaks were not doing anything, since they break out of the switch, not the `for` on line 241. Collapsed all three cases of "no-op" into a single line.