### PR TITLE
Added `SetAutoMergeCellsByColumnIndex` used to configure columns to auto-merge. Closes #67, #150.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,41 @@ table.Render()
 +----------+--------------------------+-------+---------+
 ```
 
+#### Example 7  - Identical cells merging (specify the column index to merge)
+```go
+data := [][]string{
+  []string{"1/1/2014", "Domain name", "1234", "$10.98"},
+  []string{"1/1/2014", "January Hosting", "1234", "$10.98"},
+  []string{"1/4/2014", "February Hosting", "3456", "$51.00"},
+  []string{"1/4/2014", "February Extra Bandwidth", "4567", "$30.00"},
+}
+
+table := tablewriter.NewWriter(os.Stdout)
+table.SetHeader([]string{"Date", "Description", "CV2", "Amount"})
+table.SetFooter([]string{"", "", "Total", "$146.93"})
+table.SetAutoMergeCellsByColumnIndex([]int{2, 3})
+table.SetRowLine(true)
+table.AppendBulk(data)
+table.Render()
+```
+
+##### Output 7
+```
++----------+--------------------------+-------+---------+
+|   DATE   |       DESCRIPTION        |  CV2  | AMOUNT  |
++----------+--------------------------+-------+---------+
+| 1/1/2014 | Domain name              |  1234 | $10.98  |
++----------+--------------------------+       +         +
+| 1/1/2014 | January Hosting          |       |         |
++----------+--------------------------+-------+---------+
+| 1/4/2014 | February Hosting         |  3456 | $51.00  |
++----------+--------------------------+-------+---------+
+| 1/4/2014 | February Extra Bandwidth |  4567 | $30.00  |
++----------+--------------------------+-------+---------+
+|                                       TOTAL | $146.93 |
++----------+--------------------------+-------+---------+
+```
+
 
 #### Table with color
 ```go
@@ -233,7 +268,7 @@ table.Render()
 #### Table with color Output
 ![Table with Color](https://cloud.githubusercontent.com/assets/6460392/21101956/bbc7b356-c0a1-11e6-9f36-dba694746efc.png)
 
-#### Example - 7 Table Cells with Color
+#### Example - 8 Table Cells with Color
 
 Individual Cell Colors from `func Rich` take precedence over Column Colors
 
@@ -289,7 +324,7 @@ table.Render()
 ##### Table cells with color Output
 ![Table cells with Color](https://user-images.githubusercontent.com/9064687/63969376-bcd88d80-ca6f-11e9-9466-c3d954700b25.png)
 
-#### Example 8 - Set table caption
+#### Example 9 - Set table caption
 ```go
 data := [][]string{
     []string{"A", "The Good", "500"},
@@ -310,7 +345,7 @@ table.Render() // Send output
 
 Note: Caption text will wrap with total width of rendered table.
 
-##### Output 7
+##### Output 9
 ```
 +------+-----------------------+--------+
 | NAME |         SIGN          | RATING |
@@ -323,7 +358,7 @@ Note: Caption text will wrap with total width of rendered table.
 Movie ratings.
 ```
 
-#### Example 8 - Set NoWhiteSpace and TablePadding option
+#### Example 10 - Set NoWhiteSpace and TablePadding option
 ```go
 data := [][]string{
     {"node1.example.com", "Ready", "compute", "1.11"},
@@ -349,7 +384,7 @@ table.AppendBulk(data) // Add Bulk Data
 table.Render()
 ```
 
-##### Output 8
+##### Output 10
 ```
 NAME             	STATUS  	ROLE   	VERSION 
 node1.example.com	Ready   	compute	1.11   	

--- a/table.go
+++ b/table.go
@@ -48,39 +48,40 @@ type Border struct {
 }
 
 type Table struct {
-	out            io.Writer
-	rows           [][]string
-	lines          [][][]string
-	cs             map[int]int
-	rs             map[int]int
-	headers        [][]string
-	footers        [][]string
-	caption        bool
-	captionText    string
-	autoFmt        bool
-	autoWrap       bool
-	reflowText     bool
-	mW             int
-	pCenter        string
-	pRow           string
-	pColumn        string
-	tColumn        int
-	tRow           int
-	hAlign         int
-	fAlign         int
-	align          int
-	newLine        string
-	rowLine        bool
-	autoMergeCells bool
-	noWhiteSpace   bool
-	tablePadding   string
-	hdrLine        bool
-	borders        Border
-	colSize        int
-	headerParams   []string
-	columnsParams  []string
-	footerParams   []string
-	columnsAlign   []int
+	out                     io.Writer
+	rows                    [][]string
+	lines                   [][][]string
+	cs                      map[int]int
+	rs                      map[int]int
+	headers                 [][]string
+	footers                 [][]string
+	caption                 bool
+	captionText             string
+	autoFmt                 bool
+	autoWrap                bool
+	reflowText              bool
+	mW                      int
+	pCenter                 string
+	pRow                    string
+	pColumn                 string
+	tColumn                 int
+	tRow                    int
+	hAlign                  int
+	fAlign                  int
+	align                   int
+	newLine                 string
+	rowLine                 bool
+	autoMergeCells          bool
+	columnsToAutoMergeCells []int
+	noWhiteSpace            bool
+	tablePadding            string
+	hdrLine                 bool
+	borders                 Border
+	colSize                 int
+	headerParams            []string
+	columnsParams           []string
+	footerParams            []string
+	columnsAlign            []int
 }
 
 // Start New Table
@@ -274,6 +275,13 @@ func (t *Table) SetRowLine(line bool) {
 // This would enable / disable the merge of cells with identical values
 func (t *Table) SetAutoMergeCells(auto bool) {
 	t.autoMergeCells = auto
+}
+
+// Set Auto Merge Cells By Column Index
+// This would enable / disable the merge of cells with identical values for specific columns
+func (t *Table) SetAutoMergeCellsByColumnIndex(cols []int) {
+	t.autoMergeCells = true
+	t.columnsToAutoMergeCells = cols
 }
 
 // Set Table Border
@@ -830,9 +838,23 @@ func (t *Table) printRowMergeCells(writer io.Writer, columns [][]string, rowIdx 
 			}
 
 			if t.autoMergeCells {
+				var mergeCell bool
+				if t.columnsToAutoMergeCells != nil {
+					// Check to see if the column index is in columnsToAutoMergeCells.
+					for _, c := range t.columnsToAutoMergeCells {
+						if y == c {
+							// index found.
+							mergeCell = true
+							break
+						}
+					}
+				} else {
+					// columnsToAutoMergeCells was not set or was set to nil.
+					mergeCell = true
+				}
 				//Store the full line to merge mutli-lines cells
 				fullLine := strings.TrimRight(strings.Join(columns[y], " "), " ")
-				if len(previousLine) > y && fullLine == previousLine[y] && fullLine != "" {
+				if len(previousLine) > y && fullLine == previousLine[y] && fullLine != "" && mergeCell {
 					// If this cell is identical to the one above but not empty, we don't display the border and keep the cell empty.
 					displayCellBorder = append(displayCellBorder, false)
 					str = ""

--- a/table.go
+++ b/table.go
@@ -72,7 +72,7 @@ type Table struct {
 	newLine                 string
 	rowLine                 bool
 	autoMergeCells          bool
-	columnsToAutoMergeCells []int
+	columnsToAutoMergeCells map[int]bool
 	noWhiteSpace            bool
 	tablePadding            string
 	hdrLine                 bool
@@ -279,9 +279,17 @@ func (t *Table) SetAutoMergeCells(auto bool) {
 
 // Set Auto Merge Cells By Column Index
 // This would enable / disable the merge of cells with identical values for specific columns
+// If cols is empty, it is the same as `SetAutoMergeCells(true)`.
 func (t *Table) SetAutoMergeCellsByColumnIndex(cols []int) {
 	t.autoMergeCells = true
-	t.columnsToAutoMergeCells = cols
+
+	if len(cols) > 0 {
+		m := make(map[int]bool)
+		for _, col := range cols {
+			m[col] = true
+		}
+		t.columnsToAutoMergeCells = m
+	}
 }
 
 // Set Table Border
@@ -841,15 +849,11 @@ func (t *Table) printRowMergeCells(writer io.Writer, columns [][]string, rowIdx 
 				var mergeCell bool
 				if t.columnsToAutoMergeCells != nil {
 					// Check to see if the column index is in columnsToAutoMergeCells.
-					for _, c := range t.columnsToAutoMergeCells {
-						if y == c {
-							// index found.
-							mergeCell = true
-							break
-						}
+					if t.columnsToAutoMergeCells[y] {
+						mergeCell = true
 					}
 				} else {
-					// columnsToAutoMergeCells was not set or was set to nil.
+					// columnsToAutoMergeCells was not set.
 					mergeCell = true
 				}
 				//Store the full line to merge mutli-lines cells


### PR DESCRIPTION
There are a couple of issues open about `SetAutoMergeCells` not configurable per column basis. This PR fixes that.

https://github.com/olekukonko/tablewriter/issues/67
https://github.com/olekukonko/tablewriter/issues/150


`SetAutoMergeCellsByColumnIndex` takes an int slice (which represents the column indexes to auto-merge).