### PR TITLE
Fix linter warnings

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -13,7 +13,7 @@ import (
 	"os"
 )
 
-// Start A new table by importing from a CSV file
+// NewCSV starts a new table by importing from a CSV file
 // Takes io.Writer and csv File name
 func NewCSV(writer io.Writer, fileName string, hasHeader bool) (*Table, error) {
 	file, err := os.Open(fileName)
@@ -26,7 +26,7 @@ func NewCSV(writer io.Writer, fileName string, hasHeader bool) (*Table, error) {
 	return t, err
 }
 
-//  Start a New Table Writer with csv.Reader
+// NewCSVReader starts a new table Writer with csv.Reader
 // This enables customisation such as reader.Comma = ';'
 // See http://golang.org/src/pkg/encoding/csv/reader.go?s=3213:3671#L94
 func NewCSVReader(writer io.Writer, csvReader *csv.Reader, hasHeader bool) (*Table, error) {

--- a/table.go
+++ b/table.go
@@ -5,7 +5,7 @@
 // This module is a Table Writer  API for the Go Programming Language.
 // The protocols were written in pure Go and works on windows and unix systems
 
-// Create & Generate text based table
+// Package tablewriter create & generate text based table
 package tablewriter
 
 import (
@@ -17,21 +17,31 @@ import (
 )
 
 const (
+	// MAX_ROW_WIDTH is a maximum row width
 	MAX_ROW_WIDTH = 30
 )
 
 const (
-	CENTER  = "+"
-	ROW     = "-"
-	COLUMN  = "|"
-	SPACE   = " "
+	// CENTER separator for center
+	CENTER = "+"
+	// ROW separator for rows
+	ROW = "-"
+	// COLUMN separator for columns
+	COLUMN = "|"
+	// SPACE space separator
+	SPACE = " "
+	// NEWLINE new line
 	NEWLINE = "\n"
 )
 
 const (
+	// ALIGN_DEFAULT align default
 	ALIGN_DEFAULT = iota
+	// ALIGN_CENTER center align
 	ALIGN_CENTER
+	// ALIGN_RIGHT right align
 	ALIGN_RIGHT
+	// ALIGN_LEFT left align
 	ALIGN_LEFT
 )
 
@@ -40,6 +50,7 @@ var (
 	percent = regexp.MustCompile(`^-?\d+\.?\d*$%$`)
 )
 
+// Border defines a border type
 type Border struct {
 	Left   bool
 	Right  bool
@@ -47,6 +58,7 @@ type Border struct {
 	Bottom bool
 }
 
+// Table defines a table to render
 type Table struct {
 	out                     io.Writer
 	rows                    [][]string
@@ -84,7 +96,7 @@ type Table struct {
 	columnsAlign            []int
 }
 
-// Start New Table
+// NewWriter starts a new table
 // Take io.Writer Directly
 func NewWriter(writer io.Writer) *Table {
 	t := &Table{
@@ -147,7 +159,7 @@ const (
 	footerRowIdx = -2
 )
 
-// Set table header
+// SetHeader sets table header.
 func (t *Table) SetHeader(keys []string) {
 	t.colSize = len(keys)
 	for i, v := range keys {
@@ -156,7 +168,7 @@ func (t *Table) SetHeader(keys []string) {
 	}
 }
 
-// Set table Footer
+// SetFooter sets table Footer.
 func (t *Table) SetFooter(keys []string) {
 	//t.colSize = len(keys)
 	for i, v := range keys {
@@ -165,7 +177,7 @@ func (t *Table) SetFooter(keys []string) {
 	}
 }
 
-// Set table Caption
+// SetCaption sets table Caption.
 func (t *Table) SetCaption(caption bool, captionText ...string) {
 	t.caption = caption
 	if len(captionText) == 1 {
@@ -173,71 +185,72 @@ func (t *Table) SetCaption(caption bool, captionText ...string) {
 	}
 }
 
-// Turn header autoformatting on/off. Default is on (true).
+// SetAutoFormatHeaders turns header autoformatting on/off. Default is on (true).
 func (t *Table) SetAutoFormatHeaders(auto bool) {
 	t.autoFmt = auto
 }
 
-// Turn automatic multiline text adjustment on/off. Default is on (true).
+// SetAutoWrapText turns automatic multiline text adjustment on/off. Default is on (true).
 func (t *Table) SetAutoWrapText(auto bool) {
 	t.autoWrap = auto
 }
 
-// Turn automatic reflowing of multiline text when rewrapping. Default is on (true).
+// SetReflowDuringAutoWrap turns automatic reflowing of multiline text when rewrapping. Default is on (true).
 func (t *Table) SetReflowDuringAutoWrap(auto bool) {
 	t.reflowText = auto
 }
 
-// Set the Default column width
+// SetColWidth sets the Default column width.
 func (t *Table) SetColWidth(width int) {
 	t.mW = width
 }
 
-// Set the minimal width for a column
+// SetColMinWidth sets the minimal width for a column.
 func (t *Table) SetColMinWidth(column int, width int) {
 	t.cs[column] = width
 }
 
-// Set the Column Separator
+// SetColumnSeparator sets the Column Separator.
 func (t *Table) SetColumnSeparator(sep string) {
 	t.pColumn = sep
 }
 
-// Set the Row Separator
+// SetRowSeparator sets the Row Separator.
 func (t *Table) SetRowSeparator(sep string) {
 	t.pRow = sep
 }
 
-// Set the center Separator
+// SetCenterSeparator sets the center Separator.
 func (t *Table) SetCenterSeparator(sep string) {
 	t.pCenter = sep
 }
 
-// Set Header Alignment
+// SetHeaderAlignment sets Header Alignment.
 func (t *Table) SetHeaderAlignment(hAlign int) {
 	t.hAlign = hAlign
 }
 
-// Set Footer Alignment
+// SetFooterAlignment sets Footer Alignment.
 func (t *Table) SetFooterAlignment(fAlign int) {
 	t.fAlign = fAlign
 }
 
-// Set Table Alignment
+// SetAlignment sets Table Alignment.
 func (t *Table) SetAlignment(align int) {
 	t.align = align
 }
 
-// Set No White Space
+// SetNoWhiteSpace sets No White Space.
 func (t *Table) SetNoWhiteSpace(allow bool) {
 	t.noWhiteSpace = allow
 }
 
-// Set Table Padding
+// SetTablePadding sets Table Padding.
 func (t *Table) SetTablePadding(padding string) {
 	t.tablePadding = padding
 }
 
+// SetColumnAlignment sets alignment type.
 func (t *Table) SetColumnAlignment(keys []int) {
 	for _, v := range keys {
 		switch v {
@@ -254,30 +267,30 @@ func (t *Table) SetColumnAlignment(keys []int) {
 	}
 }
 
-// Set New Line
+// SetNewLine sets new line.
 func (t *Table) SetNewLine(nl string) {
 	t.newLine = nl
 }
 
-// Set Header Line
+// SetHeaderLine sets header line.
 // This would enable / disable a line after the header
 func (t *Table) SetHeaderLine(line bool) {
 	t.hdrLine = line
 }
 
-// Set Row Line
+// SetRowLine sets row line.
 // This would enable / disable a line on each row of the table
 func (t *Table) SetRowLine(line bool) {
 	t.rowLine = line
 }
 
-// Set Auto Merge Cells
+// SetAutoMergeCells sets auto merge cells.
 // This would enable / disable the merge of cells with identical values
 func (t *Table) SetAutoMergeCells(auto bool) {
 	t.autoMergeCells = auto
 }
 
-// Set Auto Merge Cells By Column Index
+// SetAutoMergeCellsByColumnIndex sets auto merge cells by column index.
 // This would enable / disable the merge of cells with identical values for specific columns
 // If cols is empty, it is the same as `SetAutoMergeCells(true)`.
 func (t *Table) SetAutoMergeCellsByColumnIndex(cols []int) {
@@ -292,12 +305,13 @@ func (t *Table) SetAutoMergeCellsByColumnIndex(cols []int) {
 	}
 }
 
-// Set Table Border
+// SetBorder sets table border.
 // This would enable / disable line around the table
 func (t *Table) SetBorder(border bool) {
 	t.SetBorders(Border{border, border, border, border})
 }
 
+// SetBorders sets borders
 func (t *Table) SetBorders(border Border) {
 	t.borders = border
 }
@@ -324,7 +338,7 @@ func (t *Table) Append(row []string) {
 	t.lines = append(t.lines, line)
 }
 
-// Append row to table with color attributes
+// Rich appends row to table with color attributes.
 func (t *Table) Rich(row []string, colors []Colors) {
 	rowSize := len(t.headers)
 	if rowSize > t.colSize {
@@ -351,7 +365,7 @@ func (t *Table) Rich(row []string, colors []Colors) {
 	t.lines = append(t.lines, line)
 }
 
-// Allow Support for Bulk Append
+// AppendBulk allows support for Bulk Append
 // Eliminates repeated for loops
 func (t *Table) AppendBulk(rows [][]string) {
 	for _, row := range rows {
@@ -364,12 +378,12 @@ func (t *Table) NumLines() int {
 	return len(t.lines)
 }
 
-// Clear rows
+// ClearRows clears rows.
 func (t *Table) ClearRows() {
 	t.lines = [][][]string{}
 }
 
-// Clear footer
+// ClearFooter clears footer.
 func (t *Table) ClearFooter() {
 	t.footers = [][]string{}
 }
@@ -454,9 +468,9 @@ func (t *Table) printHeading() {
 	padFunc := pad(t.hAlign)
 
 	// Checking for ANSI escape sequences for header
-	is_esc_seq := false
+	isEscSeq := false
 	if len(t.headerParams) > 0 {
-		is_esc_seq = true
+		isEscSeq = true
 	}
 
 	// Maximum height.
@@ -484,7 +498,7 @@ func (t *Table) printHeading() {
 			if t.noWhiteSpace {
 				pad = ConditionString((y == end && !t.borders.Left), SPACE, t.tablePadding)
 			}
-			if is_esc_seq {
+			if isEscSeq {
 				if !t.noWhiteSpace {
 					fmt.Fprintf(t.out, " %s %s",
 						format(padFunc(h, SPACE, v),
@@ -534,9 +548,9 @@ func (t *Table) printFooter() {
 	padFunc := pad(t.fAlign)
 
 	// Checking for ANSI escape sequences for header
-	is_esc_seq := false
+	isEscSeq := false
 	if len(t.footerParams) > 0 {
-		is_esc_seq = true
+		isEscSeq = true
 	}
 
 	// Maximum height.
@@ -565,7 +579,7 @@ func (t *Table) printFooter() {
 				erasePad[y] = true
 			}
 
-			if is_esc_seq {
+			if isEscSeq {
 				fmt.Fprintf(t.out, " %s %s",
 					format(padFunc(f, SPACE, v),
 						t.footerParams[y]), pad)
@@ -708,9 +722,9 @@ func (t *Table) printRow(columns [][]string, rowIdx int) {
 	pads := []int{}
 
 	// Checking for ANSI escape sequences for columns
-	is_esc_seq := false
+	isEscSeq := false
 	if len(t.columnsParams) > 0 {
-		is_esc_seq = true
+		isEscSeq = true
 	}
 	t.fillAlignment(total)
 
@@ -735,7 +749,7 @@ func (t *Table) printRow(columns [][]string, rowIdx int) {
 			str := columns[y][x]
 
 			// Embedding escape sequence with column value
-			if is_esc_seq {
+			if isEscSeq {
 				str = format(str, t.columnsParams[y])
 			}
 
@@ -815,9 +829,9 @@ func (t *Table) printRowMergeCells(writer io.Writer, columns [][]string, rowIdx 
 	pads := []int{}
 
 	// Checking for ANSI escape sequences for columns
-	is_esc_seq := false
+	isEscSeq := false
 	if len(t.columnsParams) > 0 {
-		is_esc_seq = true
+		isEscSeq = true
 	}
 	for i, line := range columns {
 		length := len(line)
@@ -841,7 +855,7 @@ func (t *Table) printRowMergeCells(writer io.Writer, columns [][]string, rowIdx 
 			str := columns[y][x]
 
 			// Embedding escape sequence with column value
-			if is_esc_seq {
+			if isEscSeq {
 				str = format(str, t.columnsParams[y])
 			}
 

--- a/table_with_color.go
+++ b/table_with_color.go
@@ -6,60 +6,100 @@ import (
 	"strings"
 )
 
+// ESC escape symbol
 const ESC = "\033"
+
+// SEP separate symbol
 const SEP = ";"
 
 const (
+	// BgBlackColor black background color
 	BgBlackColor int = iota + 40
+	// BgRedColor red background color
 	BgRedColor
+	// BgGreenColor green background color
 	BgGreenColor
+	// BgYellowColor yellow background color
 	BgYellowColor
+	// BgBlueColor blue background color
 	BgBlueColor
+	// BgMagentaColor magenta background color
 	BgMagentaColor
+	// BgCyanColor cyan background color
 	BgCyanColor
+	// BgWhiteColor white background color
 	BgWhiteColor
 )
 
 const (
+	// FgBlackColor black foreground color
 	FgBlackColor int = iota + 30
+	// FgRedColor red foreground color
 	FgRedColor
+	// FgGreenColor green foreground color
 	FgGreenColor
+	// FgYellowColor yellow foreground color
 	FgYellowColor
+	// FgBlueColor blue foreground color
 	FgBlueColor
+	// FgMagentaColor magenta foreground color
 	FgMagentaColor
+	// FgCyanColor cyan foreground color
 	FgCyanColor
+	// FgWhiteColor white foreground color
 	FgWhiteColor
 )
 
 const (
+	// BgHiBlackColor black bright background color
 	BgHiBlackColor int = iota + 100
+	// BgHiRedColor red bright background color
 	BgHiRedColor
+	// BgHiGreenColor green bright background color
 	BgHiGreenColor
+	// BgHiYellowColor yellow bright background color
 	BgHiYellowColor
+	// BgHiBlueColor blue bright background color
 	BgHiBlueColor
+	// BgHiMagentaColor magenta bright background color
 	BgHiMagentaColor
+	// BgHiCyanColor cyan bright background color
 	BgHiCyanColor
+	// BgHiWhiteColor white bright background color
 	BgHiWhiteColor
 )
 
 const (
+	// FgHiBlackColor black bright foreground color
 	FgHiBlackColor int = iota + 90
+	// FgHiRedColor red bright foreground color
 	FgHiRedColor
+	// FgHiGreenColor green bright foreground color
 	FgHiGreenColor
+	// FgHiYellowColor yellow bright foreground color
 	FgHiYellowColor
+	// FgHiBlueColor blue bright foreground color
 	FgHiBlueColor
+	// FgHiMagentaColor magenta bright foreground color
 	FgHiMagentaColor
+	// FgHiCyanColor cyan bright foreground color
 	FgHiCyanColor
+	// FgHiWhiteColor white bright foreground color
 	FgHiWhiteColor
 )
 
 const (
-	Normal          = 0
-	Bold            = 1
+	// Normal normal style
+	Normal = 0
+	// Bold bold style
+	Bold = 1
+	// UnderlineSingle underline style
 	UnderlineSingle = 4
+	// Italic italic style
 	Italic
 )
 
+// Colors contains colors
 type Colors []int
 
 func startFormat(seq string) string {
@@ -101,7 +141,7 @@ func format(s string, codes interface{}) string {
 	return startFormat(seq) + s + stopFormat()
 }
 
-// Adding header colors (ANSI codes)
+// SetHeaderColor adding header colors (ANSI codes)
 func (t *Table) SetHeaderColor(colors ...Colors) {
 	if t.colSize != len(colors) {
 		panic("Number of header colors must be equal to number of headers.")
@@ -111,7 +151,7 @@ func (t *Table) SetHeaderColor(colors ...Colors) {
 	}
 }
 
-// Adding column colors (ANSI codes)
+// SetColumnColor adding column colors (ANSI codes)
 func (t *Table) SetColumnColor(colors ...Colors) {
 	if t.colSize != len(colors) {
 		panic("Number of column colors must be equal to number of headers.")
@@ -121,7 +161,7 @@ func (t *Table) SetColumnColor(colors ...Colors) {
 	}
 }
 
-// Adding column colors (ANSI codes)
+// SetFooterColor adding column colors (ANSI codes)
 func (t *Table) SetFooterColor(colors ...Colors) {
 	if len(t.footers) != len(colors) {
 		panic("Number of footer colors must be equal to number of footer.")
@@ -131,6 +171,7 @@ func (t *Table) SetFooterColor(colors ...Colors) {
 	}
 }
 
+// Color returns colors
 func Color(colors ...int) []int {
 	return colors
 }

--- a/util.go
+++ b/util.go
@@ -17,12 +17,14 @@ import (
 
 var ansi = regexp.MustCompile("\033\\[(?:[0-9]{1,3}(?:;[0-9]{1,3})*)?[m|K]")
 
+// DisplayWidth returns string's size (without spaces)
 func DisplayWidth(str string) int {
 	return runewidth.StringWidth(ansi.ReplaceAllLiteralString(str, ""))
 }
 
 // Simple Condition for string
-// Returns value based on condition
+
+// ConditionString returns value based on condition
 func ConditionString(cond bool, valid, inValid string) string {
 	if cond {
 		return valid
@@ -35,7 +37,8 @@ func isNumOrSpace(r rune) bool {
 }
 
 // Format Table Header
-// Replace _ , . and spaces
+
+// Title replace _ , . and spaces
 func Title(name string) string {
 	origLen := len(name)
 	rs := []rune(name)
@@ -72,7 +75,7 @@ func Pad(s, pad string, width int) string {
 	return s
 }
 
-// Pad String Right position
+// PadRight pad string right position
 // This would place string at the left side of the screen
 func PadRight(s, pad string, width int) string {
 	gap := width - DisplayWidth(s)
@@ -82,7 +85,7 @@ func PadRight(s, pad string, width int) string {
 	return s
 }
 
-// Pad String Left position
+// PadLeft pad string left position
 // This would place string at the right side of the screen
 func PadLeft(s, pad string, width int) string {
 	gap := width - DisplayWidth(s)

--- a/wrap.go
+++ b/wrap.go
@@ -21,7 +21,7 @@ var (
 
 const defaultPenalty = 1e5
 
-// Wrap wraps s into a paragraph of lines of length lim, with minimal
+// WrapString wraps s into a paragraph of lines of length lim, with minimal
 // raggedness.
 func WrapString(s string, lim int) ([]string, int) {
 	words := strings.Split(strings.Replace(s, nl, sp, -1), sp)


### PR DESCRIPTION
Fixed linter's warnings:

```sh
➜ golint                    
csv.go:16:1: comment on exported function NewCSV should be of the form "NewCSV ..."
csv.go:29:1: comment on exported function NewCSVReader should be of the form "NewCSVReader ..."
table.go:8:1: package comment should be of the form "Package tablewriter ..."
table.go:20:2: don't use ALL_CAPS in Go names; use CamelCase
table.go:20:2: exported const MAX_ROW_WIDTH should have comment (or a comment on this block) or be unexported
table.go:24:2: exported const CENTER should have comment (or a comment on this block) or be unexported
table.go:32:2: don't use ALL_CAPS in Go names; use CamelCase
table.go:32:2: exported const ALIGN_DEFAULT should have comment (or a comment on this block) or be unexported
table.go:33:2: don't use ALL_CAPS in Go names; use CamelCase
table.go:34:2: don't use ALL_CAPS in Go names; use CamelCase
table.go:35:2: don't use ALL_CAPS in Go names; use CamelCase
table.go:43:6: exported type Border should have comment or be unexported
table.go:50:6: exported type Table should have comment or be unexported
table.go:87:1: comment on exported function NewWriter should be of the form "NewWriter ..."
table.go:150:1: comment on exported method Table.SetHeader should be of the form "SetHeader ..."
table.go:159:1: comment on exported method Table.SetFooter should be of the form "SetFooter ..."
table.go:168:1: comment on exported method Table.SetCaption should be of the form "SetCaption ..."
table.go:176:1: comment on exported method Table.SetAutoFormatHeaders should be of the form "SetAutoFormatHeaders ..."
table.go:181:1: comment on exported method Table.SetAutoWrapText should be of the form "SetAutoWrapText ..."
table.go:186:1: comment on exported method Table.SetReflowDuringAutoWrap should be of the form "SetReflowDuringAutoWrap ..."
table.go:191:1: comment on exported method Table.SetColWidth should be of the form "SetColWidth ..."
table.go:196:1: comment on exported method Table.SetColMinWidth should be of the form "SetColMinWidth ..."
table.go:201:1: comment on exported method Table.SetColumnSeparator should be of the form "SetColumnSeparator ..."
table.go:206:1: comment on exported method Table.SetRowSeparator should be of the form "SetRowSeparator ..."
table.go:211:1: comment on exported method Table.SetCenterSeparator should be of the form "SetCenterSeparator ..."
table.go:216:1: comment on exported method Table.SetHeaderAlignment should be of the form "SetHeaderAlignment ..."
table.go:221:1: comment on exported method Table.SetFooterAlignment should be of the form "SetFooterAlignment ..."
table.go:226:1: comment on exported method Table.SetAlignment should be of the form "SetAlignment ..."
table.go:231:1: comment on exported method Table.SetNoWhiteSpace should be of the form "SetNoWhiteSpace ..."
table.go:236:1: comment on exported method Table.SetTablePadding should be of the form "SetTablePadding ..."
table.go:241:1: exported method Table.SetColumnAlignment should have comment or be unexported
table.go:257:1: comment on exported method Table.SetNewLine should be of the form "SetNewLine ..."
table.go:262:1: comment on exported method Table.SetHeaderLine should be of the form "SetHeaderLine ..."
table.go:268:1: comment on exported method Table.SetRowLine should be of the form "SetRowLine ..."
table.go:274:1: comment on exported method Table.SetAutoMergeCells should be of the form "SetAutoMergeCells ..."
table.go:280:1: comment on exported method Table.SetAutoMergeCellsByColumnIndex should be of the form "SetAutoMergeCellsByColumnIndex ..."
table.go:295:1: comment on exported method Table.SetBorder should be of the form "SetBorder ..."
table.go:301:1: exported method Table.SetBorders should have comment or be unexported
table.go:327:1: comment on exported method Table.Rich should be of the form "Rich ..."
table.go:354:1: comment on exported method Table.AppendBulk should be of the form "AppendBulk ..."
table.go:367:1: comment on exported method Table.ClearRows should be of the form "ClearRows ..."
table.go:372:1: comment on exported method Table.ClearFooter should be of the form "ClearFooter ..."
table.go:457:2: don't use underscores in Go names; var is_esc_seq should be isEscSeq
table.go:537:2: don't use underscores in Go names; var is_esc_seq should be isEscSeq
table.go:711:2: don't use underscores in Go names; var is_esc_seq should be isEscSeq
table.go:818:2: don't use underscores in Go names; var is_esc_seq should be isEscSeq
table_with_color.go:9:7: exported const ESC should have comment or be unexported
table_with_color.go:10:7: exported const SEP should have comment or be unexported
table_with_color.go:13:2: exported const BgBlackColor should have comment (or a comment on this block) or be unexported
table_with_color.go:24:2: exported const FgBlackColor should have comment (or a comment on this block) or be unexported
table_with_color.go:35:2: exported const BgHiBlackColor should have comment (or a comment on this block) or be unexported
table_with_color.go:46:2: exported const FgHiBlackColor should have comment (or a comment on this block) or be unexported
table_with_color.go:57:2: exported const Normal should have comment (or a comment on this block) or be unexported
table_with_color.go:63:6: exported type Colors should have comment or be unexported
table_with_color.go:104:1: comment on exported method Table.SetHeaderColor should be of the form "SetHeaderColor ..."
table_with_color.go:114:1: comment on exported method Table.SetColumnColor should be of the form "SetColumnColor ..."
table_with_color.go:124:1: comment on exported method Table.SetFooterColor should be of the form "SetFooterColor ..."
table_with_color.go:134:1: exported function Color should have comment or be unexported
util.go:20:1: exported function DisplayWidth should have comment or be unexported
util.go:24:1: comment on exported function ConditionString should be of the form "ConditionString ..."
util.go:37:1: comment on exported function Title should be of the form "Title ..."
util.go:75:1: comment on exported function PadRight should be of the form "PadRight ..."
util.go:85:1: comment on exported function PadLeft should be of the form "PadLeft ..."
wrap.go:24:1: comment on exported function WrapString should be of the form "WrapString ..."
```

Did not touch uppercase consts from `table.go` as they may be used in the client's code.