### PR TITLE
 Add poweron architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
-
+arch:
+   - ppc64le
+   - amd64
 go:
-  - 1.1
-  - 1.2
   - 1.3
   - 1.4
   - 1.5
@@ -12,3 +12,11 @@ go:
   - 1.9
   - "1.10"
   - tip
+jobs:
+  exclude :
+    - arch : ppc64le
+      go :
+       - 1.3
+    - arch : ppc64le
+      go :
+       - 1.4


### PR DESCRIPTION
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,For more info tag @gerrith3.

