### PR TITLE
fix: column misalignment when header is empty

### DIFF
--- a/table.go
+++ b/table.go
@@ -809,8 +809,10 @@ func (t *Table) printRow(columns [][]string, rowIdx int) {
 		length := len(line)
 		pad := max - length
 		pads = append(pads, pad)
+		// used to fill empty rows
+		empty := strings.Repeat(" ", len(line))
 		for n := 0; n < pad; n++ {
-			columns[i] = append(columns[i], "  ")
+			columns[i] = append(columns[i], empty)
 		}
 	}
 	//fmt.Println(max, "\n")

--- a/table_test.go
+++ b/table_test.go
@@ -1377,3 +1377,38 @@ func TestStructs(t *testing.T) {
 		})
 	}
 }
+
+func TestAlignWithEmptyHeader(t *testing.T) {
+	var (
+		buf    = &bytes.Buffer{}
+		table  = NewWriter(buf)
+		header = []string{"", "", "col2"}
+		lines  = []string{
+			"Lorem ipsum dolor",
+			"quis commodo odio",
+		}
+		linesWithNewline = strings.Join(lines, "\n")
+		data             = [][]string{
+			{" ", "b", "c"},
+			{" ", "e", linesWithNewline},
+		}
+		want = `    |   |       COL2         
+----+---+--------------------
+    | b | c                  
+----+---+--------------------
+    | e | Lorem ipsum dolor  
+    |   | quis commodo odio  
+----+---+--------------------
+`
+	)
+	table.SetHeader(header)
+	table.SetBorder(false)
+	table.SetColMinWidth(2, 15)
+	table.SetAutoWrapText(false)
+	table.SetRowLine(true)
+	table.AppendBulk(data)
+
+	table.Render()
+
+	checkEqual(t, buf.String(), want)
+}


### PR DESCRIPTION
Calculate the empty row to use for padding instead of assuming an empty rows is always length=2