### PR TITLE
Fix the problem that the column color cannot be set without setting the header 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+.idea

--- a/table.go
+++ b/table.go
@@ -399,6 +399,9 @@ func (t *Table) Append(row []string) {
 	if rowSize > t.colSize {
 		t.colSize = rowSize
 	}
+	if len(row) > t.colSize {
+		t.colSize = len(row)
+	}
 
 	n := len(t.lines)
 	line := [][]string{}


### PR DESCRIPTION
Fix the problem that the column background color cannot be set without setting the header (SetHeader).

For Example: 
```go
tData := [][]string{
	{"Name", "Heat Unit", "Peppers"},
	{"Bell Pepper", "0", "0"},
}
table := tablewriter.NewWriter(tStr)
table.AppendBulk(tData)
tColColor := make([]tablewriter.Colors, 0)
for i := 0; i < len(data); i++ {
	tColColor = append(tColColor, tablewriter.Colors{tablewriter.Normal, tablewriter.FgHiWhiteColor})
}
table.SetColumnColor(tColColor...)
```