### PR TITLE
CI: bump workflow's versions, fix Node 12 deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
       - name: "go vet"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
       - name: "go vet"


### PR DESCRIPTION
## Changes

- Bump `actions/checkout` from `v2` (Node 12) to `v4` (Node 20).
- Bump `actions/setup-go` from `v2` (Node 12) to `v5` (Node 20). [This change will also improve the workflow's performance as the version's release adds support for caching.]

## Context

Node 16 reached eol recently, GitHub removed support for it last month, currently all runners default to Node 18 or newer even if the workflow uses other Node versions.