### PR TITLE
Ansi color code leak fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.12
 require (
 	github.com/jwalton/gchalk v1.3.0
 	github.com/mattn/go-runewidth v0.0.10
+	golang.org/x/term v0.13.0
 )

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,10 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef h1:fPxZ3Umkct3LZ8gK9nbk+DWDJ9fstZa2grBn+lWVKPs=
 golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.13.0 h1:bb+I9cTfFazGW51MZqBVmZy7+JEJMouUHTUSKVQLBek=
+golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=

--- a/table_with_color.go
+++ b/table_with_color.go
@@ -2,8 +2,11 @@ package tablewriter
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
+
+	"golang.org/x/term"
 )
 
 const ESC = "\033"
@@ -103,6 +106,10 @@ func format(s string, codes interface{}) string {
 
 // Adding header colors (ANSI codes)
 func (t *Table) SetHeaderColor(colors ...Colors) {
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		return
+	}
+
 	if t.colSize != len(colors) {
 		panic("Number of header colors must be equal to number of headers.")
 	}

--- a/table_with_color_test.go
+++ b/table_with_color_test.go
@@ -1,0 +1,82 @@
+// Copyright 2014 Oleku Konko All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// This module is a Table Writer  API for the Go Programming Language.
+// The protocols were written in pure Go and works on windows and unix systems
+
+package tablewriter
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestSetHeaderColorTTY(t *testing.T) {
+	data := [][]string{
+		{"A", "The Good", "500"},
+		{"B", "The Very very Bad Man", "288"},
+		{"C", "The Ugly", "120"},
+		{"D", "The Gopher", "800"},
+	}
+
+	var buf bytes.Buffer
+	table := NewWriter(&buf)
+	table.SetHeader([]string{"Name", "Sign", "Rating"})
+	table.SetHeaderColor(Colors{Bold, FgHiYellowColor}, Colors{Bold, FgHiYellowColor}, Colors{Bold, FgHiYellowColor})
+
+	for _, v := range data {
+		table.Append(v)
+	}
+
+	table.SetAutoMergeCells(true)
+	table.SetRowLine(true)
+	table.Render()
+
+	// table := NewWriter(os.Stdout)
+	var want []string
+	want = append(want, "1;93", "1;93", "1;93")
+
+	// The color codes are added in case of TTY output.
+	got := table.headerParams
+
+	checkEqual(t, got, want, "SetHeaderColor when TTY is attached failed")
+}
+
+func createTempFile(t *testing.T) *os.File {
+	tempFile, err := os.CreateTemp("", "output-*.txt")
+	if err != nil {
+		t.Fatalf("Failed to create a temporary file: %v", err)
+	}
+	return tempFile
+}
+
+func TestSetHeaderColorNonTTY(t *testing.T) {
+	data := [][]string{
+		{"A", "The Good", "500"},
+		{"B", "The Very very Bad Man", "288"},
+		{"C", "The Ugly", "120"},
+		{"D", "The Gopher", "800"},
+	}
+
+	os.Stdout = createTempFile(t)
+	table := NewWriter(os.Stdout)
+
+	table.SetHeader([]string{"Name", "Sign", "Rating"})
+	want := table.headerParams
+	table.SetHeaderColor(Colors{Bold, FgHiYellowColor}, Colors{Bold, FgHiYellowColor}, Colors{Bold, FgHiYellowColor})
+
+	for _, v := range data {
+		table.Append(v)
+	}
+
+	table.SetAutoMergeCells(true)
+	table.SetRowLine(true)
+	table.Render()
+
+	// The color codes are not added in case of non TTY output.
+	got := table.headerParams
+
+	checkEqual(t, got, want, "SetHeaderColor when TTY is not attached failed")
+}


### PR DESCRIPTION
Added a check to ensure that the ANSI colour codes in the headers are skipped when the output is redirected to the files.

The ANSI colour codes will only be present if the output file descriptor is TTY.