### PR TITLE
feat: merge line to reduce height

### DIFF
--- a/util.go
+++ b/util.go
@@ -17,8 +17,19 @@ import (
 
 var ansi = regexp.MustCompile("\033\\[(?:[0-9]{1,3}(?:;[0-9]{1,3})*)?[m|K]")
 
+var linkRe = regexp.MustCompile(`\x1b]8;;.*?\x1b\\(.*?)(\x1b]8;;\x1b\\)?`)
+
 func DisplayWidth(str string) int {
-	return runewidth.StringWidth(ansi.ReplaceAllLiteralString(str, ""))
+	linkFreeText := CleanHyperlinksInTerminalEmulators(str)
+	return runewidth.StringWidth(ansi.ReplaceAllLiteralString(linkFreeText, ""))
+}
+
+// CleanHyperlinksInTerminalEmulators
+// https://github.com/Alhadis/OSC8-Adoption/
+// printf '\033]8;;http://example.com\033\\This is a link\033]8;;\033\\\n'
+// -> "This is a link\n"
+func CleanHyperlinksInTerminalEmulators(str string) string {
+	return linkRe.ReplaceAllString(str, "$1")
 }
 
 // ConditionString Simple Condition for string

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,31 @@
+package tablewriter
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCleanHyperlinksInTerminalEmulators(t *testing.T) {
+	testInput := "\033]8;;http://example.com\033\\This is a link\033]8;;\033\\\n"
+	expectedOutput := "This is a link\n"
+	actualOutput := CleanHyperlinksInTerminalEmulators(testInput)
+	if actualOutput != expectedOutput {
+		t.Errorf("Expected %s, got %s", expectedOutput, actualOutput)
+	}
+	expectedOutputSize := len(expectedOutput)
+	actualOutputSize := len(actualOutput)
+	if actualOutputSize != expectedOutputSize {
+		t.Errorf("Expected size %d, got size %d", expectedOutputSize, actualOutputSize)
+	}
+	testInput2 := strings.Repeat(testInput, 10)
+	expectedOutput2 := strings.Repeat(expectedOutput, 10)
+	actualOutput2 := CleanHyperlinksInTerminalEmulators(testInput2)
+	if actualOutput2 != expectedOutput2 {
+		t.Errorf("Expected %s, got %s", expectedOutput2, actualOutput2)
+	}
+	expectedOutputSize2 := len(expectedOutput2)
+	actualOutputSize2 := len(actualOutput2)
+	if actualOutputSize2 != expectedOutputSize2 {
+		t.Errorf("Expected size %d, got size %d", expectedOutputSize2, actualOutputSize2)
+	}
+}


### PR DESCRIPTION
When using `SetAutoMergeCellsByColumnIndex`, there are wasted space in table. Because we print empty line in merged cells.
This pr will merge lines with the same column value in `SetAutoMergeCellsByColumnIndex` to reduce hight