### PR TITLE
fix(panic): when len(footers) is less than columns

### DIFF
--- a/table.go
+++ b/table.go
@@ -692,7 +692,7 @@ func (t *Table) printFooter() {
 	max := t.rs[footerRowIdx]
 
 	// Print Footer
-	for i := 0; i < (len(t.cs) - len(t.footers)); i++ {
+	for len(t.cs)-len(t.footers) > 0 {
 		lines := t.parseDimension(" ", len(t.footers), footerRowIdx)
 		t.footers = append(t.footers, lines)
 	}

--- a/table_test.go
+++ b/table_test.go
@@ -1309,13 +1309,13 @@ func TestLessFooterColumnsThanHeaders(t *testing.T) {
 		data   = [][]string{
 			{"1", "2", "3"},
 		}
-		footer = []string{"a", "b"}
+		footer = []string{"a"}
 		want   = `+---+---+---+
 | A | B | C |
 +---+---+---+
 | 1 | 2 | 3 |
 +---+---+---+
-| A | B |   |
+| A |   |   |
 +---+---+---+
 `
 	)


### PR DESCRIPTION
continue https://github.com/olekukonko/tablewriter/pull/215
- that pr fixed only `len(columns) - len(footer) == 1 ` case, i.e:
- this fixes further panics when `len(columns) - len(footer) > 1 `