### PR TITLE
Caption & Max Width

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ go get github.com/olekukonko/tablewriter@v0.0.5
 #### Latest  Version
 The latest stable version
 ```bash
-go get github.com/olekukonko/tablewriter@v1.0.3
+go get github.com/olekukonko/tablewriter@v1.0.4
 ```
 
 **Warning:** Version `v1.0.0` contains missing functionality and should not be used.
@@ -77,7 +77,7 @@ func main() {
 │   PACKAGE   │ VERSION │ STATUS │
 ├─────────────┼─────────┼────────┤
 │ tablewriter │ v0.0.5  │ legacy │
-│ tablewriter │ v1.0.3  │ latest │
+│ tablewriter │ v1.0.4  │ latest │
 └─────────────┴─────────┴────────┘
 ```
 
@@ -369,10 +369,10 @@ func main() {
 		tablewriter.WithConfig(tablewriter.Config{
 			Row: tw.CellConfig{
 				Formatting: tw.CellFormatting{
-					MaxWidth:  25,            // Limit column width
 					AutoWrap:  tw.WrapNormal, // Wrap long content
 					Alignment: tw.AlignLeft,  // Left-align rows
 				},
+				ColMaxWidths: tw.CellWidth{Global: 25},
 			},
 			Footer: tw.CellConfig{
 				Formatting: tw.CellFormatting{Alignment: tw.AlignRight},
@@ -655,13 +655,9 @@ func main() {
   A | A  │  B | B  
  ---+--- │ ---+--- 
   A | A  │  B | B  
- ---+--- │ ---+--- 
-         │         
   C | C  │  D | D  
  ---+--- │ ---+--- 
-  C | C  │  D | D  
- ---+--- │ ---+--- 
-         │         
+  C | C  │  D | D   
 ```
 
 #### 9. Structs with Database

--- a/config.go
+++ b/config.go
@@ -165,7 +165,7 @@ func (b *ConfigBuilder) WithFooterMaxWidth(maxWidth int) *ConfigBuilder {
 	if maxWidth < 0 {
 		return b
 	}
-	b.config.Footer.Formatting.MaxWidth = maxWidth
+	b.config.Footer.ColMaxWidths.Global = maxWidth
 	return b
 }
 
@@ -217,7 +217,7 @@ func (b *ConfigBuilder) WithHeaderMaxWidth(maxWidth int) *ConfigBuilder {
 	if maxWidth < 0 {
 		return b
 	}
-	b.config.Header.Formatting.MaxWidth = maxWidth
+	b.config.Header.ColMaxWidths.Global = maxWidth
 	return b
 }
 
@@ -280,7 +280,7 @@ func (b *ConfigBuilder) WithRowMaxWidth(maxWidth int) *ConfigBuilder {
 	if maxWidth < 0 {
 		return b
 	}
-	b.config.Row.Formatting.MaxWidth = maxWidth
+	b.config.Row.ColMaxWidths.Global = maxWidth
 	return b
 }
 
@@ -371,13 +371,13 @@ func (ff *FooterFormattingBuilder) WithAutoWrap(autoWrap int) *FooterFormattingB
 
 // WithMaxWidth sets the maximum content width for footer cells.
 // Negative values are ignored.
-func (ff *FooterFormattingBuilder) WithMaxWidth(maxWidth int) *FooterFormattingBuilder {
-	if maxWidth < 0 {
-		return ff
-	}
-	ff.config.MaxWidth = maxWidth
-	return ff
-}
+//func (ff *FooterFormattingBuilder) WithMaxWidth(maxWidth int) *FooterFormattingBuilder {
+//	if maxWidth < 0 {
+//		return ff
+//	}
+//	ff.config.Foo = maxWidth
+//	return ff
+//}
 
 // WithNewarkMode sets the merge behavior for footer cells (likely a typo, should be WithMergeMode).
 // Invalid merge modes are ignored.
@@ -489,13 +489,13 @@ func (hf *HeaderFormattingBuilder) WithAutoWrap(autoWrap int) *HeaderFormattingB
 
 // WithMaxWidth sets the maximum content width for header cells.
 // Negative values are ignored.
-func (hf *HeaderFormattingBuilder) WithMaxWidth(maxWidth int) *HeaderFormattingBuilder {
-	if maxWidth < 0 {
-		return hf
-	}
-	hf.config.MaxWidth = maxWidth
-	return hf
-}
+//func (hf *HeaderFormattingBuilder) WithMaxWidth(maxWidth int) *HeaderFormattingBuilder {
+//	if maxWidth < 0 {
+//		return hf
+//	}
+//	hf.config.MaxWidth = maxWidth
+//	return hf
+//}
 
 // WithMergeMode sets the merge behavior for header cells.
 // Invalid merge modes are ignored.
@@ -610,13 +610,13 @@ func (rf *RowFormattingBuilder) WithAutoWrap(autoWrap int) *RowFormattingBuilder
 
 // WithMaxWidth sets the maximum content width for row cells.
 // Negative values are ignored.
-func (rf *RowFormattingBuilder) WithMaxWidth(maxWidth int) *RowFormattingBuilder {
-	if maxWidth < 0 {
-		return rf
-	}
-	rf.config.MaxWidth = maxWidth
-	return rf
-}
+//func (rf *RowFormattingBuilder) WithMaxWidth(maxWidth int) *RowFormattingBuilder {
+//	if maxWidth < 0 {
+//		return rf
+//	}
+//	rf.config.MaxWidth = maxWidth
+//	return rf
+//}
 
 // WithMergeMode sets the merge behavior for row cells.
 // Invalid merge modes are ignored.
@@ -867,7 +867,7 @@ func WithRowMaxWidth(maxWidth int) Option {
 		if maxWidth < 0 {
 			return
 		}
-		target.config.Row.Formatting.MaxWidth = maxWidth
+		target.config.Row.ColMaxWidths.Global = maxWidth
 		if target.logger != nil {
 			target.logger.Debug("Option: WithRowMaxWidth applied to Table: %v", maxWidth)
 		}
@@ -945,7 +945,6 @@ func defaultConfig() Config {
 		MaxWidth: 0,
 		Header: tw.CellConfig{
 			Formatting: tw.CellFormatting{
-				MaxWidth:   0,
 				AutoWrap:   tw.WrapTruncate,
 				Alignment:  tw.AlignCenter,
 				AutoFormat: true,
@@ -957,7 +956,6 @@ func defaultConfig() Config {
 		},
 		Row: tw.CellConfig{
 			Formatting: tw.CellFormatting{
-				MaxWidth:   0,
 				AutoWrap:   tw.WrapNormal,
 				Alignment:  tw.AlignLeft,
 				AutoFormat: false,
@@ -969,7 +967,6 @@ func defaultConfig() Config {
 		},
 		Footer: tw.CellConfig{
 			Formatting: tw.CellFormatting{
-				MaxWidth:   0,
 				AutoWrap:   tw.WrapNormal,
 				Alignment:  tw.AlignRight,
 				AutoFormat: false,
@@ -997,8 +994,8 @@ func mergeCellConfig(dst, src tw.CellConfig) tw.CellConfig {
 	if src.Formatting.AutoWrap != 0 {
 		dst.Formatting.AutoWrap = src.Formatting.AutoWrap
 	}
-	if src.Formatting.MaxWidth != 0 {
-		dst.Formatting.MaxWidth = src.Formatting.MaxWidth
+	if src.ColMaxWidths.Global != 0 {
+		dst.ColMaxWidths.Global = src.ColMaxWidths.Global
 	}
 	if src.Formatting.MergeMode != 0 {
 		dst.Formatting.MergeMode = src.Formatting.MergeMode

--- a/renderer/markdown.go
+++ b/renderer/markdown.go
@@ -149,7 +149,7 @@ func (m *Markdown) resolveAlignment(ctx tw.Formatting) tw.Alignment {
 		m.alignment[i] = ctx.Row.Current[i].Align
 	}
 
-	m.logger.Debug(" → Alignment Resolved %s", m.alignment)
+	m.logger.Debug(" → Align Resolved %s", m.alignment)
 	return m.alignment
 }
 

--- a/stream.go
+++ b/stream.go
@@ -80,7 +80,6 @@ func (t *Table) Close() error {
 func (t *Table) Start() error {
 	t.ensureInitialized() // Ensures basic setup like loggers
 
-	// --- MODIFIED LOGIC START ---
 	if !t.config.Stream.Enable {
 		// Start() should only be called when streaming is explicitly enabled.
 		// Otherwise, the user should call Render() for batch mode.
@@ -761,7 +760,7 @@ func (t *Table) streamRenderFooter(processedFooterLines [][]string) error {
 	f := t.renderer
 	cfg := t.renderer.Config()
 
-	// --- Render Row/Footer or Header/Footer Separator Line ---
+	//  Render Row/Footer or Header/Footer Separator Line
 	// This separator is drawn if ShowFooterLine is enabled AND there was content before the footer.
 	// The last rendered position (t.lastRenderedPosition) should be Row or Header or "separator".
 	if (t.lastRenderedPosition == tw.Row || t.lastRenderedPosition == tw.Header || t.lastRenderedPosition == tw.Position("separator")) &&
@@ -819,7 +818,7 @@ func (t *Table) streamRenderFooter(processedFooterLines [][]string) error {
 		t.lastRenderedMergeState = nil
 		t.logger.Debug("streamRenderFooter: Footer separator line rendered.")
 	}
-	// --- End Render Separator Line ---
+	//  End Render Separator Line
 
 	// Detect horizontal merges for the footer section based on its (assumed stored) raw input.
 	// This is tricky because streamStoreFooter gets []string, but prepareWithMerges expects [][]string.

--- a/tablewriter_test.go
+++ b/tablewriter_test.go
@@ -52,11 +52,11 @@ func TestCalculateContentMaxWidth(t *testing.T) {
 	table := NewTable(os.Stdout)
 	config := tw.CellConfig{
 		Formatting: tw.CellFormatting{
-			MaxWidth:   10,
 			AutoWrap:   tw.WrapTruncate,
 			Alignment:  tw.AlignLeft,
 			AutoFormat: false,
 		},
+		ColMaxWidths: tw.CellWidth{Global: 10},
 		Padding: tw.CellPadding{
 			Global: tw.Padding{Left: " ", Right: " "},
 		},
@@ -77,7 +77,7 @@ func TestCalculateContentMaxWidth(t *testing.T) {
 		}
 	})
 	t.Run("No Constraint in Batch", func(t *testing.T) {
-		config.Formatting.MaxWidth = 0
+		config.ColMaxWidths.Global = 0
 		got := table.calculateContentMaxWidth(0, config, 1, 1, false)
 		if got != 0 {
 			t.Errorf("Expected width 0, got %d", got)
@@ -319,7 +319,6 @@ func TestMergeCellConfig(t *testing.T) {
 			AutoWrap:   tw.WrapNormal, // 1
 			AutoFormat: false,
 			MergeMode:  tw.MergeNone,
-			MaxWidth:   0,
 		},
 		Padding: tw.CellPadding{
 			Global: tw.Padding{Left: " ", Right: " "},
@@ -341,7 +340,6 @@ func TestMergeCellConfig(t *testing.T) {
 					AutoWrap:   tw.WrapNormal,
 					AutoFormat: false,
 					MergeMode:  tw.MergeNone,
-					MaxWidth:   0,
 				},
 				Padding: tw.CellPadding{
 					Global: tw.Padding{Left: " ", Right: " "},
@@ -362,7 +360,6 @@ func TestMergeCellConfig(t *testing.T) {
 					AutoWrap:   tw.WrapNormal,
 					AutoFormat: false,
 					MergeMode:  tw.MergeNone,
-					MaxWidth:   0,
 				},
 				Padding: tw.CellPadding{
 					Global: tw.Padding{Left: " ", Right: " "},
@@ -383,7 +380,6 @@ func TestMergeCellConfig(t *testing.T) {
 					AutoWrap:   tw.WrapNormal,
 					AutoFormat: false,
 					MergeMode:  tw.MergeVertical,
-					MaxWidth:   0,
 				},
 				Padding: tw.CellPadding{
 					Global: tw.Padding{Left: " ", Right: " "},
@@ -404,7 +400,6 @@ func TestMergeCellConfig(t *testing.T) {
 					AutoWrap:   tw.WrapNormal,
 					AutoFormat: false,
 					MergeMode:  tw.MergeHorizontal,
-					MaxWidth:   0,
 				},
 				Padding: tw.CellPadding{
 					Global: tw.Padding{Left: " ", Right: " "},
@@ -425,7 +420,6 @@ func TestMergeCellConfig(t *testing.T) {
 					AutoWrap:   tw.WrapNormal,
 					AutoFormat: false,
 					MergeMode:  tw.MergeBoth,
-					MaxWidth:   0,
 				},
 				Padding: tw.CellPadding{
 					Global: tw.Padding{Left: " ", Right: " "},
@@ -446,7 +440,6 @@ func TestMergeCellConfig(t *testing.T) {
 					AutoWrap:   tw.WrapNormal,
 					AutoFormat: false,
 					MergeMode:  tw.MergeHierarchical,
-					MaxWidth:   0,
 				},
 				Padding: tw.CellPadding{
 					Global: tw.Padding{Left: " ", Right: " "},
@@ -467,7 +460,6 @@ func TestMergeCellConfig(t *testing.T) {
 					AutoWrap:   tw.WrapTruncate,    // From defaultConfig() Header
 					AutoFormat: true,               // From defaultConfig() Header
 					MergeMode:  tw.MergeHorizontal, // From builder
-					MaxWidth:   0,
 				},
 				Padding: tw.CellPadding{
 					Global: tw.Padding{Left: " ", Right: " "},
@@ -532,7 +524,7 @@ func TestMergeCellConfig2(t *testing.T) {
 		input       tw.CellConfig
 		expected    tw.CellConfig
 	}{
-		// --- Test Cases for ROW section (using defaultConfig().Row as base) ---
+		//  Test Cases for ROW section (using defaultConfig().Row as base)
 		{
 			name:        "Row_EmptyInput",
 			baseSection: "row",
@@ -587,7 +579,7 @@ func TestMergeCellConfig2(t *testing.T) {
 				return cfg
 			}(),
 		},
-		// --- Test Cases for HEADER section (using defaultConfig().Header as base) ---
+		//  Test Cases for HEADER section (using defaultConfig().Header as base)
 		{
 			name:        "Header_FromBuilderFlattened",
 			baseSection: "header",

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -26,7 +26,7 @@ func TestBasicTableDefault(t *testing.T) {
 	│ Bob   │ 30  │ Boston   │
 	└───────┴─────┴──────────┘
 `
-	debug := visualCheck(t, "BasicTableRendering", buf.String(), expected)
+	debug := visualCheck(t, "TestBasicTableDefault", buf.String(), expected)
 	if !debug {
 		t.Error(table.Debug().String())
 	}
@@ -34,12 +34,6 @@ func TestBasicTableDefault(t *testing.T) {
 
 func TestBasicTableDefaultBorder(t *testing.T) {
 	var buf bytes.Buffer
-
-	//table := tablewriter.NewTable(&buf)
-	//table.Header([]string{"Name", "Age", "City"})
-	//table.Append([]string{"Alice", "25", "New York"})
-	//table.Append([]string{"Bob", "30", "Boston"})
-	//table.Render()
 
 	t.Run("all-off", func(t *testing.T) {
 		buf.Reset()
@@ -61,7 +55,7 @@ func TestBasicTableDefaultBorder(t *testing.T) {
          Bob   │ 30  │ Boston   
 `
 
-		visualCheck(t, "BasicTableRendering-all-off", buf.String(), expected)
+		visualCheck(t, "TestBasicTableDefaultBorder-top-off", buf.String(), expected)
 
 	})
 
@@ -87,7 +81,7 @@ func TestBasicTableDefaultBorder(t *testing.T) {
 
 `
 
-		visualCheck(t, "BasicTableRendering-top-on", buf.String(), expected)
+		visualCheck(t, "TestBasicTableDefaultBorder-top-on", buf.String(), expected)
 	})
 
 	t.Run("mix", func(t *testing.T) {
@@ -112,7 +106,7 @@ func TestBasicTableDefaultBorder(t *testing.T) {
         ───────┴─────┴──────────┘
 
 `
-		visualCheck(t, "BasicTableRendering-mix", buf.String(), expected)
+		visualCheck(t, "TestBasicTableDefaultBorder-mix", buf.String(), expected)
 
 	})
 }
@@ -353,10 +347,11 @@ func TestLongHeaders(t *testing.T) {
 
 	t.Run("long-headers", func(t *testing.T) {
 		c := tablewriter.Config{
-			MaxWidth: 30,
 			Header: tw.CellConfig{Formatting: tw.CellFormatting{
 				AutoWrap: tw.WrapTruncate,
-			}},
+			},
+				ColMaxWidths: tw.CellWidth{Global: 30},
+			},
 			Debug: false,
 		}
 		buf.Reset()
@@ -374,7 +369,7 @@ func TestLongHeaders(t *testing.T) {
             │ Bob   │ 30  │ Boston                      │
             └───────┴─────┴─────────────────────────────┘
 `
-		if !visualCheck(t, "BasicTableRendering", buf.String(), expected) {
+		if !visualCheck(t, "TestLongHeaders", buf.String(), expected) {
 			t.Log(table.Debug())
 		}
 
@@ -384,10 +379,10 @@ func TestLongHeaders(t *testing.T) {
 		buf.Reset()
 
 		c := tablewriter.Config{
-			MaxWidth: 30,
 			Header: tw.CellConfig{Formatting: tw.CellFormatting{
 				AutoWrap: tw.WrapNormal,
-			}},
+			},
+				ColMaxWidths: tw.CellWidth{Global: 30}},
 		}
 
 		table := tablewriter.NewTable(&buf, tablewriter.WithConfig(c))
@@ -423,21 +418,20 @@ func TestLongValues(t *testing.T) {
 	c := tablewriter.Config{
 		Header: tw.CellConfig{
 			Formatting: tw.CellFormatting{
-				MaxWidth:   30,
 				Alignment:  tw.AlignCenter,
 				AutoFormat: true,
 			},
+			ColMaxWidths: tw.CellWidth{Global: 30},
 		},
 		Row: tw.CellConfig{
 			Formatting: tw.CellFormatting{
-				MaxWidth:  30,
 				AutoWrap:  tw.WrapNormal,
 				Alignment: tw.AlignLeft,
 			},
+			ColMaxWidths: tw.CellWidth{Global: 30},
 		},
 		Footer: tw.CellConfig{
 			Formatting: tw.CellFormatting{
-				MaxWidth:  30,
 				Alignment: tw.AlignRight,
 			},
 			ColumnAligns: []tw.Align{tw.Skip, tw.Skip, tw.Skip, tw.AlignLeft},
@@ -499,16 +493,16 @@ func TestWrapping(t *testing.T) {
 		},
 		Row: tw.CellConfig{
 			Formatting: tw.CellFormatting{
-				MaxWidth:  30,
 				AutoWrap:  tw.WrapBreak,
 				Alignment: tw.AlignLeft,
 			},
+			ColMaxWidths: tw.CellWidth{Global: 30},
 		},
 		Footer: tw.CellConfig{
 			Formatting: tw.CellFormatting{
-				MaxWidth:  30,
 				Alignment: tw.AlignRight,
 			},
+			ColMaxWidths: tw.CellWidth{Global: 30},
 		},
 	}
 

--- a/tests/caption_test.go
+++ b/tests/caption_test.go
@@ -1,0 +1,261 @@
+// File: tests/caption_test.go
+package tests
+
+import (
+	"bytes"
+	"github.com/olekukonko/tablewriter/renderer"
+	"testing"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/olekukonko/tablewriter/tw" // Assuming your tw types (CaptionPosition, Align) are here
+)
+
+// TestTableCaptions comprehensive tests for caption functionality
+func TestTableCaptions(t *testing.T) {
+	data := [][]string{
+		{"Alice", "30", "New York"},
+		{"Bob", "24", "San Francisco"},
+		{"Charlie", "35", "London"},
+	}
+	headers := []string{"Name", "Age", "City"}
+	shortCaption := "User Data"
+	longCaption := "This is a detailed caption for the user data table, intended to demonstrate text wrapping and alignment features."
+
+	baseTableSetup := func(buf *bytes.Buffer) *tablewriter.Table {
+		table := tablewriter.NewTable(buf,
+			tablewriter.WithRenderer(renderer.NewBlueprint(tw.Rendition{Symbols: tw.NewSymbols(tw.StyleASCII)})),
+			tablewriter.WithDebug(true),
+		)
+		table.Header(headers)
+		for _, v := range data {
+			table.Append(v)
+		}
+		return table
+	}
+
+	t.Run("NoCaption", func(t *testing.T) {
+		var buf bytes.Buffer
+		table := baseTableSetup(&buf)
+		table.Render()
+		expected := `
++---------+-----+---------------+
+|  NAME   | AGE |     CITY      |
++---------+-----+---------------+
+| Alice   | 30  | New York      |
+| Bob     | 24  | San Francisco |
+| Charlie | 35  | London        |
++---------+-----+---------------+
+`
+		if !visualCheckCaption(t, t.Name(), buf.String(), expected) {
+			t.Log(table.Debug().String())
+		}
+	})
+
+	t.Run("LegacySetCaption_BottomCenter", func(t *testing.T) {
+		var buf bytes.Buffer
+		table := baseTableSetup(&buf)
+		table.Caption(tw.Caption{Text: shortCaption}) // Legacy, defaults to BottomCenter, auto width
+		table.Render()
+		// Width of table: 7+3+15 + 4 borders/separators = 29. "User Data" is 9.
+		// (29-9)/2 = 10 padding left.
+		expected := `
++---------+-----+---------------+
+|  NAME   | AGE |     CITY      |
++---------+-----+---------------+
+| Alice   | 30  | New York      |
+| Bob     | 24  | San Francisco |
+| Charlie | 35  | London        |
++---------+-----+---------------+
+			User Data    
+`
+		if !visualCheckCaption(t, t.Name(), buf.String(), expected) {
+			t.Log(table.Debug().String())
+		}
+	})
+
+	t.Run("CaptionBottomCenter_AutoWidthBottom", func(t *testing.T) {
+		var buf bytes.Buffer
+		table := baseTableSetup(&buf)
+		table.Caption(tw.Caption{Text: shortCaption, Spot: tw.SpotBottomCenter, Align: tw.AlignCenter})
+		table.Render()
+		expected := `
++---------+-----+---------------+
+|  NAME   | AGE |     CITY      |
++---------+-----+---------------+
+| Alice   | 30  | New York      |
+| Bob     | 24  | San Francisco |
+| Charlie | 35  | London        |
++---------+-----+---------------+
+          User Data
+`
+		if !visualCheckCaption(t, t.Name(), buf.String(), expected) {
+			t.Log(table.Debug().String())
+		}
+	})
+
+	t.Run("CaptionTopCenter_AutoWidthTop", func(t *testing.T) {
+		var buf bytes.Buffer
+		table := baseTableSetup(&buf)
+		table.Caption(tw.Caption{Text: shortCaption, Spot: tw.SpotTopCenter, Align: tw.AlignCenter})
+		table.Render()
+		expected := `
+			User Data            
++---------+-----+---------------+
+|  NAME   | AGE |     CITY      |
++---------+-----+---------------+
+| Alice   | 30  | New York      |
+| Bob     | 24  | San Francisco |
+| Charlie | 35  | London        |
++---------+-----+---------------+
+`
+		if !visualCheckCaption(t, t.Name(), buf.String(), expected) {
+			t.Log(table.Debug().String())
+		}
+	})
+
+	t.Run("CaptionBottomLeft_AutoWidth", func(t *testing.T) {
+		var buf bytes.Buffer
+		table := baseTableSetup(&buf)
+		table.Caption(tw.Caption{Text: shortCaption, Spot: tw.SpotBottomLeft, Align: tw.AlignLeft})
+		table.Render()
+		expected := `
++---------+-----+---------------+
+|  NAME   | AGE |     CITY      |
++---------+-----+---------------+
+| Alice   | 30  | New York      |
+| Bob     | 24  | San Francisco |
+| Charlie | 35  | London        |
++---------+-----+---------------+
+User Data  
+`
+		if !visualCheckCaption(t, t.Name(), buf.String(), expected) {
+			t.Log(table.Debug().String())
+		}
+	})
+
+	t.Run("CaptionTopRight_AutoWidth", func(t *testing.T) {
+		var buf bytes.Buffer
+		table := baseTableSetup(&buf)
+		table.Caption(tw.Caption{Text: shortCaption, Spot: tw.SpotTopRight, Align: tw.AlignRight})
+		table.Render()
+		expected := `
+                       User Data
++---------+-----+---------------+
+|  NAME   | AGE |     CITY      |
++---------+-----+---------------+
+| Alice   | 30  | New York      |
+| Bob     | 24  | San Francisco |
+| Charlie | 35  | London        |
++---------+-----+---------------+
+`
+		if !visualCheckCaption(t, t.Name(), buf.String(), expected) {
+			t.Log(table.Debug().String())
+		}
+	})
+
+	t.Run("CaptionBottomCenter_LongCaption_AutoWidth", func(t *testing.T) {
+		var buf bytes.Buffer
+		table := baseTableSetup(&buf)
+		table.Caption(tw.Caption{Text: longCaption, Spot: tw.SpotBottomCenter, Align: tw.AlignCenter})
+		table.Render()
+		// Table width is 29. Long caption will wrap to this.
+		// "This is a detailed caption for" (29)
+		// "the user data table, intended" (29)
+		// "to demonstrate text wrapping" (28)
+		// "and alignment features." (25)
+		expected := `
++---------+-----+---------------+
+|  NAME   | AGE |     CITY      |
++---------+-----+---------------+
+| Alice   | 30  | New York      |
+| Bob     | 24  | San Francisco |
+| Charlie | 35  | London        |
++---------+-----+---------------+
+  This is a detailed caption for 
+  the user data table, intended  
+ to demonstrate text wrapping and
+	   alignment features.  
+`
+		if !visualCheckCaption(t, t.Name(), buf.String(), expected) {
+			t.Log(table.Debug().String())
+		}
+	})
+
+	t.Run("CaptionTopLeft_LongCaption_MaxWidth20", func(t *testing.T) {
+		var buf bytes.Buffer
+		table := baseTableSetup(&buf)
+		// captionMaxWidth 20, table width is 29. Caption wraps to 20. Padded to 29 (table width) for alignment.
+		table.Caption(tw.Caption{Text: longCaption, Spot: tw.SpotTopLeft, Align: tw.AlignLeft, Width: 20})
+		table.Render()
+
+		// The visual check normalizes spaces, so the alignment padding to table width is tricky to test visually for left/right aligned captions.
+		// It's more about the wrapping width for the caption text itself.
+		// The printTopBottomCaption will align the *block* of wrapped text.
+		// Let's adjust the expected output: the lines are padded to actualTableWidth.
+		// The caption lines themselves are max 20 wide.
+		expectedAdjusted := `
+This is a detailed               
+caption for the user             
+data table, intended             
+to demonstrate                   
+text wrapping and                
+alignment features.              
++---------+-----+---------------+
+|  NAME   | AGE |     CITY      |
++---------+-----+---------------+
+| Alice   | 30  | New York      |
+| Bob     | 24  | San Francisco |
+| Charlie | 35  | London        |
++---------+-----+---------------+
+`
+		if !visualCheckCaption(t, t.Name(), buf.String(), expectedAdjusted) {
+			t.Log(table.Debug().String())
+		}
+	})
+
+	t.Run("CaptionBottomCenter_EmptyTable", func(t *testing.T) {
+		var buf bytes.Buffer
+		table := tablewriter.NewWriter(&buf)
+		// No header, no data
+		table.Caption(tw.Caption{Text: shortCaption, Spot: tw.SpotBottomCenter, Align: tw.AlignCenter})
+		table.Render()
+		// Expected: table is empty box, caption centered to its own width or a default.
+		// Empty table with default borders prints:
+		// +--+
+		// +--+
+		// If actualTableWidth is 0, captionWrapWidth becomes natural width of caption (9 for "User Data")
+		// Then paddingTargetWidth also becomes 9.
+		expected := `
++--+
++--+
+User Data
+`
+		if !visualCheckCaption(t, t.Name(), buf.String(), expected) {
+			t.Log(table.Debug().String())
+		}
+	})
+
+	t.Run("CaptionTopLeft_EmptyTable_MaxWidth10", func(t *testing.T) {
+		var buf bytes.Buffer
+		table := tablewriter.NewWriter(&buf)
+		table.Caption(tw.Caption{Text: "A very long caption text.", Spot: tw.SpotTopLeft, Align: tw.AlignLeft, Width: 10})
+		table.Render()
+		// Table is empty, captionMaxWidth is 10.
+		// "A very"
+		// "long"
+		// "caption"
+		// "text."
+		// Each line left-aligned within width 10.
+		expected := `
+A very
+long
+caption
+text.
++--+
++--+
+`
+		if !visualCheckCaption(t, t.Name(), buf.String(), expected) {
+			t.Log(table.Debug().String())
+		}
+	})
+}

--- a/tests/colorized_test.go
+++ b/tests/colorized_test.go
@@ -116,10 +116,10 @@ func TestColorizedLongValues(t *testing.T) {
 	c := tablewriter.Config{
 		Row: tw.CellConfig{
 			Formatting: tw.CellFormatting{
-				MaxWidth:  20,
 				AutoWrap:  tw.WrapNormal,
 				Alignment: tw.AlignLeft,
 			},
+			ColMaxWidths: tw.CellWidth{Global: 20},
 		},
 	}
 	table := tablewriter.NewTable(&buf,

--- a/tests/extra_test.go
+++ b/tests/extra_test.go
@@ -213,7 +213,7 @@ func TestAutoHideFeature(t *testing.T) {
 		{"E", "The Tester", "999"},
 	}
 
-	// --- Test Case 1: Hide Empty Column ---
+	//  Test Case 1: Hide Empty Column
 	t.Run("HideWhenEmpty", func(t *testing.T) {
 		var buf bytes.Buffer
 		table := tablewriter.NewTable(&buf,
@@ -257,7 +257,7 @@ func TestAutoHideFeature(t *testing.T) {
 		}
 	})
 
-	// --- Test Case 2: Show Column When Not Empty ---
+	//  Test Case 2: Show Column When Not Empty
 	t.Run("ShowWhenNotEmpty", func(t *testing.T) {
 		var buf bytes.Buffer
 		table := tablewriter.NewTable(&buf,
@@ -295,7 +295,7 @@ func TestAutoHideFeature(t *testing.T) {
 		}
 	})
 
-	// --- Test Case 3: Feature Disabled ---
+	//  Test Case 3: Feature Disabled ---
 	t.Run("DisabledShowsEmpty", func(t *testing.T) {
 		var buf bytes.Buffer
 		table := tablewriter.NewTable(&buf,

--- a/tests/fn.go
+++ b/tests/fn.go
@@ -209,3 +209,61 @@ func normalizeHTMLStrict(s string) string {
 	// Trim overall leading/trailing space that might be left.
 	return strings.TrimSpace(s)
 }
+
+// visualCheckCaption (helper function, potentially shared or adapted from your existing visualCheck)
+// Ensure this helper normalizes expected and got strings for reliable comparison
+// (e.g., trim spaces from each line, normalize newlines)
+func visualCheckCaption(t *testing.T, testName, got, expected string) bool {
+	t.Helper()
+	normalize := func(s string) string {
+		s = strings.ReplaceAll(s, "\r\n", "\n") // Normalize newlines
+		lines := strings.Split(s, "\n")
+		var trimmedLines []string
+		for _, l := range lines {
+			trimmedLines = append(trimmedLines, strings.TrimSpace(l))
+		}
+		// Join, then trim overall to handle cases where expected might have leading/trailing blank lines
+		// but individual lines should keep their relative structure.
+		return strings.TrimSpace(strings.Join(trimmedLines, "\n"))
+	}
+
+	gotNormalized := normalize(got)
+	expectedNormalized := normalize(expected)
+
+	if gotNormalized != expectedNormalized {
+		// Use a more detailed diff output if available, or just print both.
+		t.Errorf("%s: outputs do not match.\nExpected:\n```\n%s\n```\nGot:\n```\n%s\n```\n---Diff---\n%s",
+			testName, expected, got, getDiff(expectedNormalized, gotNormalized)) // You might need a diff utility
+		return false
+	}
+	return true
+}
+
+// A simple diff helper (replace with a proper library if needed)
+func getDiff(expected, actual string) string {
+	expectedLines := strings.Split(expected, "\n")
+	actualLines := strings.Split(actual, "\n")
+	maxLen := len(expectedLines)
+	if len(actualLines) > maxLen {
+		maxLen = len(actualLines)
+	}
+	var diff strings.Builder
+	diff.WriteString("Line | Expected                         | Actual\n")
+	diff.WriteString("-----|----------------------------------|----------------------------------\n")
+	for i := 0; i < maxLen; i++ {
+		eLine := ""
+		if i < len(expectedLines) {
+			eLine = expectedLines[i]
+		}
+		aLine := ""
+		if i < len(actualLines) {
+			aLine = actualLines[i]
+		}
+		marker := " "
+		if eLine != aLine {
+			marker = "!"
+		}
+		diff.WriteString(fmt.Sprintf("%4d %s| %-32s | %-32s\n", i+1, marker, eLine, aLine))
+	}
+	return diff.String()
+}

--- a/tests/markdown_test.go
+++ b/tests/markdown_test.go
@@ -103,11 +103,11 @@ func TestMarkdownUnicode(t *testing.T) {
 func TestMarkdownLongHeaders(t *testing.T) {
 	var buf bytes.Buffer
 	c := tablewriter.Config{
-		MaxWidth: 20,
 		Header: tw.CellConfig{
 			Formatting: tw.CellFormatting{
 				AutoWrap: tw.WrapTruncate,
 			},
+			ColMaxWidths: tw.CellWidth{Global: 20},
 		},
 	}
 	table := tablewriter.NewTable(&buf,
@@ -134,10 +134,10 @@ func TestMarkdownLongValues(t *testing.T) {
 	c := tablewriter.Config{
 		Row: tw.CellConfig{
 			Formatting: tw.CellFormatting{
-				MaxWidth:  20,
 				AutoWrap:  tw.WrapNormal,
 				Alignment: tw.AlignLeft,
 			},
+			ColMaxWidths: tw.CellWidth{Global: 20},
 		},
 	}
 	table := tablewriter.NewTable(&buf,

--- a/tests/ocean_test.go
+++ b/tests/ocean_test.go
@@ -71,7 +71,7 @@ func TestOceanTableStreaming_Simple(t *testing.T) {
         │ Bob  │ 30  │ Boston   │
         └──────┴─────┴──────────┘
 `
-	// Note: Alignment differences might occur if streaming path doesn't pass full CellContext for alignment
+	// Note: Align differences might occur if streaming path doesn't pass full CellContext for alignment
 	// The expected output assumes default (left) alignment for rows, center for header.
 	// Ocean's formatCellContent will apply these based on ctx.Row.Position if no cellCtx.Align.
 	if !visualCheck(t, "OceanTableStreaming_Simple", buf.String(), expected) {

--- a/tests/streamer_test.go
+++ b/tests/streamer_test.go
@@ -49,7 +49,7 @@ func TestStreamTableDefault(t *testing.T) {
 	│ Bob   │ 30  │ Boston   │
 	└───────┴─────┴──────────┘
 `
-		debug := visualCheck(t, "BasicTableRendering", buf.String(), expected)
+		debug := visualCheck(t, "TestStreamTableDefault", buf.String(), expected)
 		if !debug {
 			t.Error(table.Debug().String())
 		}
@@ -358,7 +358,8 @@ func TestStreamTruncation(t *testing.T) {
 			tablewriter.Config{
 				Header: tw.CellConfig{Formatting: tw.CellFormatting{Alignment: tw.AlignCenter}},
 				Row: tw.CellConfig{
-					Formatting: tw.CellFormatting{Alignment: tw.AlignLeft, AutoWrap: tw.WrapTruncate, MaxWidth: 13},
+					Formatting:   tw.CellFormatting{Alignment: tw.AlignLeft, AutoWrap: tw.WrapTruncate},
+					ColMaxWidths: tw.CellWidth{Global: 13},
 				},
 				Stream: tw.StreamConfig{
 					Enable: true,

--- a/tw/cell.go
+++ b/tw/cell.go
@@ -5,8 +5,8 @@ type CellFormatting struct {
 	Alignment  Align // Text alignment within the cell (e.g., Left, Right, Center)
 	AutoWrap   int   // Wrapping behavior (e.g., WrapTruncate, WrapNormal)
 	AutoFormat bool  // Enables automatic formatting (e.g., title case for headers)
-	MaxWidth   int   // Maximum content width for the cell
-	MergeMode  int   // Bitmask for merge behavior (e.g., MergeHorizontal, MergeVertical)
+	// MaxWidth   int   // Maximum content width for the cell
+	MergeMode int // Bitmask for merge behavior (e.g., MergeHorizontal, MergeVertical)
 }
 
 // CellPadding defines padding settings for table cells.

--- a/tw/fn.go
+++ b/tw/fn.go
@@ -205,6 +205,25 @@ func PadLeft(s, pad string, width int) string {
 	return s
 }
 
+// Pad aligns a string within a specified width using a padding character.
+// It truncates if the string is wider than the target width.
+func Pad(s string, padChar string, totalWidth int, alignment Align) string {
+	sDisplayWidth := DisplayWidth(s)
+	if sDisplayWidth > totalWidth {
+		return TruncateString(s, totalWidth) // Only truncate if necessary
+	}
+	switch alignment {
+	case AlignLeft:
+		return PadRight(s, padChar, totalWidth)
+	case AlignRight:
+		return PadLeft(s, padChar, totalWidth)
+	case AlignCenter:
+		return PadCenter(s, padChar, totalWidth)
+	default:
+		return PadRight(s, padChar, totalWidth)
+	}
+}
+
 // IsIsNumericOrSpace checks if a rune is a digit or space character.
 // Used in formatting logic to determine safe character replacements.
 func IsIsNumericOrSpace(r rune) bool {

--- a/tw/tw.go
+++ b/tw/tw.go
@@ -77,3 +77,21 @@ const (
 	CharEllipsis = "…" // Ellipsis character for truncation
 	CharBreak    = "↩" // Break character for wrapping
 )
+
+type Spot int
+
+const (
+	SpotNone Spot = iota
+	SpotTopLeft
+	SpotTopCenter
+	SpotTopRight
+	SpotBottomLeft
+	SpotBottomCenter // Default for legacy SetCaption
+	SpotBottomRight
+	SpotLeftTop
+	SpotLeftCenter
+	SpotLeftBottom
+	SpotRightTop
+	SpotRightCenter
+	SpotRIghtBottom
+)

--- a/tw/types.go
+++ b/tw/types.go
@@ -104,3 +104,11 @@ func (l Location) Validate() error {
 	// Return an error for any unrecognized location
 	return errors.New("invalid location")
 }
+
+type Caption struct {
+	Text    string
+	Spot    Spot
+	Align   Align
+	Width   int
+	Disable bool
+}

--- a/zoo.go
+++ b/zoo.go
@@ -638,6 +638,7 @@ func (t *Table) calculateAndNormalizeWidths(ctx *renderContext) error {
 // calculateContentMaxWidth computes the maximum content width for a column, accounting for padding and mode-specific constraints.
 // Returns the effective content width (after subtracting padding) for the given column index.
 func (t *Table) calculateContentMaxWidth(colIdx int, config tw.CellConfig, padLeftWidth, padRightWidth int, isStreaming bool) int {
+
 	var effectiveContentMaxWidth int
 	if isStreaming {
 		totalColumnWidthFromStream := t.streamWidths.Get(colIdx)
@@ -665,8 +666,8 @@ func (t *Table) calculateContentMaxWidth(colIdx int, config tw.CellConfig, padLe
 				t.logger.Debug("calculateContentMaxWidth: Batch col %d using config.ColMaxWidths.PerColumn (as total cell width constraint): %d", colIdx, constraintTotalCellWidth)
 			}
 		}
-		if !hasConstraint && config.Formatting.MaxWidth > 0 {
-			constraintTotalCellWidth = config.Formatting.MaxWidth
+		if !hasConstraint && config.ColMaxWidths.Global > 0 {
+			constraintTotalCellWidth = config.ColMaxWidths.Global
 			hasConstraint = true
 			t.logger.Debug("calculateContentMaxWidth: Batch col %d using config.Formatting.MaxWidth (as total cell width constraint): %d", colIdx, constraintTotalCellWidth)
 		}


### PR DESCRIPTION
Added support for caption and clarified `MaxWidth`, as there were so many ways to do MaxWidth. Made the `config.MaxWidth` the single source of truth; any other width should be via `ColMaxWidths`.

See:

* [https://github.com/olekukonko/tablewriter/issues/247](https://github.com/olekukonko/tablewriter/issues/247)
* [https://github.com/olekukonko/tablewriter/issues/97](https://github.com/olekukonko/tablewriter/issues/97)
