### PR TITLE
Correct debug log message for tablewriter.WithTrimSpace

### DIFF
--- a/config.go
+++ b/config.go
@@ -924,7 +924,7 @@ func WithTrimSpace(state tw.State) Option {
 	return func(target *Table) {
 		target.config.Behavior.TrimSpace = state
 		if target.logger != nil {
-			target.logger.Debug("Option: WithAutoHide applied to Table: %v", state)
+			target.logger.Debug("Option: WithTrimSpace applied to Table: %v", state)
 		}
 	}
 }


### PR DESCRIPTION
A copy/paste error resulted in the debug log message in the tablewriter.WithTrimSpace function incorrectly indicating tablewriter.WithAutoHide had been called.