### PR TITLE
fix snake_case headers

### DIFF
--- a/tablewriter.go
+++ b/tablewriter.go
@@ -854,7 +854,7 @@ func (t *Table) prepareContent(cells []string, config tw.CellConfig) [][]string 
 		effectiveContentMaxWidth := t.calculateContentMaxWidth(i, config, padLeftWidth, padRightWidth, isStreaming)
 
 		if config.Formatting.AutoFormat.Enabled() {
-			cellContent = tw.Title(strings.Join(tw.SplitCase(cellContent), tw.Space))
+			cellContent = tw.Title(strings.Join(tw.SplitCamelCase(cellContent), tw.Space))
 		}
 
 		lines := strings.Split(cellContent, "\n")

--- a/tablewriter.go
+++ b/tablewriter.go
@@ -854,7 +854,7 @@ func (t *Table) prepareContent(cells []string, config tw.CellConfig) [][]string 
 		effectiveContentMaxWidth := t.calculateContentMaxWidth(i, config, padLeftWidth, padRightWidth, isStreaming)
 
 		if config.Formatting.AutoFormat.Enabled() {
-			cellContent = tw.Title(strings.Join(tw.SplitCamelCase(cellContent), tw.Space))
+			cellContent = tw.Title(strings.Join(tw.SplitCase(cellContent), tw.Space))
 		}
 
 		lines := strings.Split(cellContent, "\n")

--- a/tw/fn.go
+++ b/tw/fn.go
@@ -245,9 +245,9 @@ func IsNumeric(s string) bool {
 	return err == nil
 }
 
-// SplitCamelCase splits a camelCase or PascalCase string into separate words.
+// SplitCase splits a camelCase or PascalCase or snake_case string into separate words.
 // It detects transitions between uppercase, lowercase, digits, and other characters.
-func SplitCamelCase(src string) (entries []string) {
+func SplitCase(src string) (entries []string) {
 	// Validate UTF-8 input; return as single entry if invalid
 	if !utf8.ValidString(src) {
 		return []string{src}
@@ -284,10 +284,11 @@ func SplitCamelCase(src string) (entries []string) {
 			runes[i] = runes[i][:len(runes[i])-1]
 		}
 	}
-	// Convert rune groups to strings, excluding empty or whitespace-only groups
+	// Convert rune groups to strings, excluding empty, underscore or whitespace-only groups
 	for _, s := range runes {
-		if len(s) > 0 && strings.TrimSpace(string(s)) != "" {
-			entries = append(entries, string(s))
+		str := string(s)
+		if len(s) > 0 && strings.TrimSpace(str) != "" && str != "_" {
+			entries = append(entries, str)
 		}
 	}
 	return

--- a/tw/fn.go
+++ b/tw/fn.go
@@ -245,9 +245,9 @@ func IsNumeric(s string) bool {
 	return err == nil
 }
 
-// SplitCase splits a camelCase or PascalCase or snake_case string into separate words.
+// SplitCamelCase splits a camelCase or PascalCase or snake_case string into separate words.
 // It detects transitions between uppercase, lowercase, digits, and other characters.
-func SplitCase(src string) (entries []string) {
+func SplitCamelCase(src string) (entries []string) {
 	// Validate UTF-8 input; return as single entry if invalid
 	if !utf8.ValidString(src) {
 		return []string{src}

--- a/tw/fn_test.go
+++ b/tw/fn_test.go
@@ -1,0 +1,49 @@
+package tw
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitCase(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{
+			input:    "",
+			expected: []string{},
+		},
+		{
+			input:    "snake_Case",
+			expected: []string{"snake", "Case"},
+		},
+		{
+			input:    "PascalCase",
+			expected: []string{"Pascal", "Case"},
+		},
+		{
+			input:    "camelCase",
+			expected: []string{"camel", "Case"},
+		},
+		{
+			input:    "_snake_CasePascalCase_camelCase123",
+			expected: []string{"snake", "Case", "Pascal", "Case", "camel", "Case", "123"},
+		},
+		{
+			input:    "ㅤ",
+			expected: []string{"ㅤ"},
+		},
+		{
+			input:    " \r\n\t",
+			expected: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if output := SplitCase(tt.input); !reflect.DeepEqual(output, tt.expected) {
+				t.Errorf("SplitCase(%q) = %v, want %v", tt.input, output, tt.expected)
+			}
+		})
+	}
+}

--- a/tw/fn_test.go
+++ b/tw/fn_test.go
@@ -41,8 +41,8 @@ func TestSplitCase(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			if output := SplitCase(tt.input); !reflect.DeepEqual(output, tt.expected) {
-				t.Errorf("SplitCase(%q) = %v, want %v", tt.input, output, tt.expected)
+			if output := SplitCamelCase(tt.input); !reflect.DeepEqual(output, tt.expected) {
+				t.Errorf("SplitCamelCase(%q) = %v, want %v", tt.input, output, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
This PR handles `snake_case` in headers. Currently it produces 3 spaces instead of 1. This PR fixes that.
```diff
- Snake   Case
+ Snake Case
```

See: 
- https://github.com/stackrox/stackrox/pull/15355#discussion_r2099716038