### PR TITLE
Improve EastAsianWidth Handling with Custom Condition

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1914,7 +1914,7 @@ func main() {
     - **Direct ANSI Codes**: Embed codes (e.g., `\033[32m` for green) in strings for manual control (`zoo.go:convertCellsToStrings`).
     - **tw.Formatter**: Implement `Format() string` on custom types to control cell output, including colors (`tw/types.go:Formatter`).
     - **tw.CellFilter**: Use `Config.<Section>.Filter.Global` or `PerColumn` to apply transformations like coloring dynamically (`tw/cell.go:CellFilter`).
-- **Width Handling**: `tw.DisplayWidth()` correctly calculates display width of ANSI-coded strings, ignoring escape sequences (`tw/fn.go:DisplayWidth`).
+- **Width Handling**: `twdw.Width()` correctly calculates display width of ANSI-coded strings, ignoring escape sequences (`tw/fn.go:DisplayWidth`).
 - **No Built-In Color Presets**: Unlike v0.0.5’s potential `tablewriter.Colors`, v1.0.x requires manual ANSI code management or external libraries for color constants.
 
 **Migration Tips**:
@@ -1928,7 +1928,7 @@ func main() {
 **Potential Pitfalls**:
 - **Terminal Support**: Some terminals may not support ANSI codes, causing artifacts; test in your environment or provide a non-colored fallback.
 - **Filter Overlap**: Combining `tw.CellFilter` with `AutoFormat` or other transformations can lead to unexpected results; prioritize filters for coloring (`zoo.go`).
-- **Width Miscalculation**: Incorrect ANSI code handling (e.g., missing `Reset`) can skew width calculations; use `tw.DisplayWidth` (`tw/fn.go`).
+- **Width Miscalculation**: Incorrect ANSI code handling (e.g., missing `Reset`) can skew width calculations; use `twdw.Width` (`tw/fn.go`).
 - **Streaming Consistency**: In streaming mode, ensure color codes are applied consistently across rows to avoid visual discrepancies (`stream.go`).
 - **Performance**: Applying filters to large datasets may add overhead; optimize filter logic for efficiency (`zoo.go`).
 
@@ -2818,7 +2818,7 @@ func main() {
 **Notes**:
 - **Configuration**: Uses `tw.CellFilter` for per-column coloring, embedding ANSI codes (`tw/cell.go`).
 - **Migration from v0.0.5**: Replaces `SetColumnColor` with dynamic filters (`tablewriter.go`).
-- **Key Features**: Flexible color application; `tw.DisplayWidth` handles ANSI codes correctly (`tw/fn.go`).
+- **Key Features**: Flexible color application; `twdw.Width` handles ANSI codes correctly (`tw/fn.go`).
 - **Best Practices**: Test in ANSI-compatible terminals; use constants for code clarity.
 - **Potential Issues**: Non-ANSI terminals may show artifacts; provide fallbacks (`tw/fn.go`).
 
@@ -3005,7 +3005,7 @@ This section addresses common migration issues with detailed solutions, covering
 | Merging not working                       | **Cause**: Streaming mode or mismatched data. **Solution**: Use batch mode for vertical/hierarchical merging; ensure identical content (`zoo.go`). |
 | Alignment ignored                         | **Cause**: `PerColumn` overrides `Global`. **Solution**: Check `Config.Section.Alignment.PerColumn` settings or `ConfigBuilder` calls (`tw/cell.go`). |
 | Padding affects widths                    | **Cause**: Padding included in `Config.Widths`. **Solution**: Adjust `Config.Widths` to account for `tw.CellPadding` (`zoo.go`). |
-| Colors not rendering                      | **Cause**: Non-ANSI terminal or incorrect codes. **Solution**: Test in ANSI-compatible terminal; use `tw.DisplayWidth` (`tw/fn.go`). |
+| Colors not rendering                      | **Cause**: Non-ANSI terminal or incorrect codes. **Solution**: Test in ANSI-compatible terminal; use `twdw.Width` (`tw/fn.go`). |
 | Caption missing                           | **Cause**: `Close()` not called in streaming or incorrect `Spot`. **Solution**: Ensure `Close()`; verify `tw.Caption.Spot` (`tablewriter.go`). |
 | Filters not applied                       | **Cause**: Incorrect `PerColumn` indexing or nil filters. **Solution**: Set filters correctly; test with sample data (`tw/cell.go`). |
 | Stringer cache overhead                   | **Cause**: Large datasets with diverse types. **Solution**: Disable `WithStringerCache` for small tables if not using `WithStringer` or if types vary greatly (`tablewriter.go`). |

--- a/deprecated.go
+++ b/deprecated.go
@@ -1,6 +1,8 @@
 package tablewriter
 
-import "github.com/olekukonko/tablewriter/tw"
+import (
+	"github.com/olekukonko/tablewriter/tw"
+)
 
 // WithBorders configures the table's border settings by updating the renderer's border configuration.
 // This function is deprecated and will be removed in a future version.

--- a/option.go
+++ b/option.go
@@ -2,6 +2,7 @@ package tablewriter
 
 import (
 	"github.com/olekukonko/ll"
+	"github.com/olekukonko/tablewriter/pkg/twwidth"
 	"github.com/olekukonko/tablewriter/tw"
 	"reflect"
 )
@@ -610,6 +611,19 @@ func WithRendition(rendition tw.Rendition) Option {
 				target.logger.Warnf("Option: WithRendition: Current renderer type %T does not implement tw.Renditioning. Rendition may not be applied as expected.", target.renderer)
 			}
 		}
+	}
+}
+
+// WithEastAsian configures the global East Asian width calculation setting.
+//   - enable=true: Enables East Asian width calculations. CJK and ambiguous characters
+//     are typically measured as double width.
+//   - enable=false: Disables East Asian width calculations. Characters are generally
+//     measured as single width, subject to Unicode standards.
+//
+// This setting affects all subsequent display width calculations using the twdw package.
+func WithEastAsian(enable bool) Option {
+	return func(target *Table) {
+		twwidth.SetEastAsian(enable)
 	}
 }
 

--- a/pkg/twwarp/wrap.go
+++ b/pkg/twwarp/wrap.go
@@ -8,12 +8,13 @@
 package twwarp
 
 import (
-	"github.com/rivo/uniseg"
 	"math"
 	"strings"
 	"unicode"
 
-	"github.com/mattn/go-runewidth"
+	"github.com/olekukonko/tablewriter/pkg/twwidth" // IMPORT YOUR NEW PACKAGE
+	"github.com/rivo/uniseg"
+	// "github.com/mattn/go-runewidth" // This can be removed if all direct uses are gone
 )
 
 const (
@@ -59,7 +60,8 @@ func WrapString(s string, lim int) ([]string, int) {
 	var lines []string
 	max := 0
 	for _, v := range words {
-		max = runewidth.StringWidth(v)
+		// max = runewidth.StringWidth(v) // OLD
+		max = twwidth.Width(v) // NEW: Use twdw.Width
 		if max > lim {
 			lim = max
 		}
@@ -82,12 +84,13 @@ func WrapStringWithSpaces(s string, lim int) ([]string, int) {
 		return []string{""}, lim
 	}
 	if strings.TrimSpace(s) == "" { // All spaces
-		if runewidth.StringWidth(s) <= lim {
-			return []string{s}, runewidth.StringWidth(s)
+		// if runewidth.StringWidth(s) <= lim { // OLD
+		if twwidth.Width(s) <= lim { // NEW: Use twdw.Width
+			// return []string{s}, runewidth.StringWidth(s) // OLD
+			return []string{s}, twwidth.Width(s) // NEW: Use twdw.Width
 		}
 		// For very long all-space strings, "wrap" by truncating to the limit.
 		if lim > 0 {
-			// Use our new helper function to get a substring of the correct display width
 			substring, _ := stringToDisplayWidth(s, lim)
 			return []string{substring}, lim
 		}
@@ -96,7 +99,6 @@ func WrapStringWithSpaces(s string, lim int) ([]string, int) {
 
 	var leadingSpaces, trailingSpaces, coreContent string
 	firstNonSpace := strings.IndexFunc(s, func(r rune) bool { return !unicode.IsSpace(r) })
-	// firstNonSpace will not be -1 due to TrimSpace check above.
 	leadingSpaces = s[:firstNonSpace]
 	lastNonSpace := strings.LastIndexFunc(s, func(r rune) bool { return !unicode.IsSpace(r) })
 	trailingSpaces = s[lastNonSpace+1:]
@@ -116,7 +118,8 @@ func WrapStringWithSpaces(s string, lim int) ([]string, int) {
 
 	maxCoreWordWidth := 0
 	for _, v := range words {
-		w := runewidth.StringWidth(v)
+		// w := runewidth.StringWidth(v) // OLD
+		w := twwidth.Width(v) // NEW: Use twdw.Width
 		if w > maxCoreWordWidth {
 			maxCoreWordWidth = w
 		}
@@ -153,15 +156,14 @@ func stringToDisplayWidth(s string, targetWidth int) (substring string, actualWi
 	g := uniseg.NewGraphemes(s)
 	for g.Next() {
 		grapheme := g.Str()
-		graphemeWidth := runewidth.StringWidth(grapheme) // Get width of the current grapheme cluster
+		// graphemeWidth := runewidth.StringWidth(grapheme) // OLD
+		graphemeWidth := twwidth.Width(grapheme) // NEW: Use twdw.Width
 
 		if currentWidth+graphemeWidth > targetWidth {
-			// Adding this grapheme would exceed the target width
 			break
 		}
 
 		currentWidth += graphemeWidth
-		// Get the end byte position of the current grapheme cluster
 		_, e := g.Positions()
 		endIndex = e
 	}
@@ -186,14 +188,15 @@ func WrapWords(words []string, spc, lim, pen int) [][]string {
 	}
 	lengths := make([]int, n)
 	for i := 0; i < n; i++ {
-		lengths[i] = runewidth.StringWidth(words[i])
+		// lengths[i] = runewidth.StringWidth(words[i]) // OLD
+		lengths[i] = twwidth.Width(words[i]) // NEW: Use twdw.Width
 	}
 	nbrk := make([]int, n)
 	cost := make([]int, n)
 	for i := range cost {
 		cost[i] = math.MaxInt32
 	}
-	remainderLen := lengths[n-1]
+	remainderLen := lengths[n-1] // Uses updated lengths
 	for i := n - 1; i >= 0; i-- {
 		if i < n-1 {
 			remainderLen += spc + lengths[i]

--- a/pkg/twwarp/wrap_test.go
+++ b/pkg/twwarp/wrap_test.go
@@ -10,6 +10,7 @@ package twwarp
 import (
 	"bytes"
 	"fmt"
+	"github.com/olekukonko/tablewriter/pkg/twwidth"
 	"github.com/olekukonko/tablewriter/tw"
 	"os"
 	"reflect"
@@ -72,14 +73,14 @@ func TestDisplayWidth(t *testing.T) {
 	if runewidth.IsEastAsian() {
 		want = 14
 	}
-	if n := tw.DisplayWidth(input); n != want {
+	if n := twwidth.Width(input); n != want {
 		t.Errorf("Wants: %d Got: %d", want, n)
 	}
 	input = "\033[43;30m" + input + "\033[00m"
-	checkEqual(t, tw.DisplayWidth(input), want)
+	checkEqual(t, twwidth.Width(input), want)
 
 	input = "\033]8;;idea://open/?file=/path/somefile.php&line=12\033\\some URL\033]8;;\033\\"
-	checkEqual(t, tw.DisplayWidth(input), 8)
+	checkEqual(t, twwidth.Width(input), 8)
 
 }
 

--- a/pkg/twwidth/width.go
+++ b/pkg/twwidth/width.go
@@ -1,0 +1,306 @@
+package twwidth
+
+import (
+	"bytes"
+	"github.com/mattn/go-runewidth"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// condition holds the global runewidth configuration, including East Asian width settings.
+var condition *runewidth.Condition
+
+// mu protects access to condition and widthCache for thread safety.
+var mu sync.Mutex
+
+// ansi is a compiled regular expression for stripping ANSI escape codes from strings.
+var ansi = Filter()
+
+func init() {
+	condition = runewidth.NewCondition()
+
+	widthCache = make(map[cacheKey]int)
+}
+
+// cacheKey is used as a key for memoizing string width results in widthCache.
+type cacheKey struct {
+	str            string // Input string
+	eastAsianWidth bool   // East Asian width setting
+}
+
+// widthCache stores memoized results of Width calculations to improve performance.
+var widthCache map[cacheKey]int
+
+// Filter compiles and returns a regular expression for matching ANSI escape sequences,
+// including CSI (Control Sequence Introducer) and OSC (Operating System Command) sequences.
+// The returned regex can be used to strip ANSI codes from strings.
+func Filter() *regexp.Regexp {
+	var regESC = "\x1b" // ASCII escape character
+	var regBEL = "\x07" // ASCII bell character
+
+	// ANSI string terminator: either ESC+\ or BEL
+	var regST = "(" + regexp.QuoteMeta(regESC+"\\") + "|" + regexp.QuoteMeta(regBEL) + ")"
+	// Control Sequence Introducer (CSI): ESC[ followed by parameters and a final byte
+	var regCSI = regexp.QuoteMeta(regESC+"[") + "[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]"
+	// Operating System Command (OSC): ESC] followed by arbitrary content until a terminator
+	var regOSC = regexp.QuoteMeta(regESC+"]") + ".*?" + regST
+
+	// Combine CSI and OSC patterns into a single regex
+	return regexp.MustCompile("(" + regCSI + "|" + regOSC + ")")
+}
+
+// SetEastAsian enables or disables East Asian width handling for width calculations.
+// When the setting changes, the width cache is cleared to ensure accuracy.
+// This function is thread-safe.
+//
+// Example:
+//
+//	twdw.SetEastAsian(true) // Enable East Asian width handling
+func SetEastAsian(enable bool) {
+	mu.Lock()
+	defer mu.Unlock()
+	if condition.EastAsianWidth != enable {
+		condition.EastAsianWidth = enable
+		widthCache = make(map[cacheKey]int) // Clear cache on setting change
+	}
+}
+
+// Width calculates the visual width of a string, excluding ANSI escape sequences,
+// using the go-runewidth package for accurate Unicode handling. It accounts for the
+// current East Asian width setting and caches results for performance.
+// This function is thread-safe.
+//
+// Example:
+//
+//	width := twdw.Width("Hello\x1b[31mWorld") // Returns 10
+func Width(str string) int {
+	mu.Lock()
+	key := cacheKey{str: str, eastAsianWidth: condition.EastAsianWidth}
+	if w, found := widthCache[key]; found {
+		mu.Unlock()
+		return w
+	}
+	mu.Unlock()
+
+	// Use a temporary condition to avoid holding the lock during calculation
+	tempCond := runewidth.NewCondition()
+	tempCond.EastAsianWidth = key.eastAsianWidth
+
+	stripped := ansi.ReplaceAllLiteralString(str, "")
+	calculatedWidth := tempCond.StringWidth(stripped)
+
+	mu.Lock()
+	widthCache[key] = calculatedWidth
+	mu.Unlock()
+
+	return calculatedWidth
+}
+
+// WidthNoCache calculates the visual width of a string without using or
+// updating the global cache. It uses the current global East Asian width setting.
+// This function is intended for internal use (e.g., benchmarking) and is thread-safe.
+//
+// Example:
+//
+//	width := twdw.WidthNoCache("Hello\x1b[31mWorld") // Returns 10
+func WidthNoCache(str string) int {
+	mu.Lock()
+	currentEA := condition.EastAsianWidth
+	mu.Unlock()
+
+	tempCond := runewidth.NewCondition()
+	tempCond.EastAsianWidth = currentEA
+
+	stripped := ansi.ReplaceAllLiteralString(str, "")
+	return tempCond.StringWidth(stripped)
+}
+
+// Display calculates the visual width of a string, excluding ANSI escape sequences,
+// using the provided runewidth condition. Unlike Width, it does not use caching
+// and is intended for cases where a specific condition is required.
+// This function is thread-safe with respect to the provided condition.
+//
+// Example:
+//
+//	cond := runewidth.NewCondition()
+//	width := twdw.Display(cond, "Hello\x1b[31mWorld") // Returns 10
+func Display(cond *runewidth.Condition, str string) int {
+	return cond.StringWidth(ansi.ReplaceAllLiteralString(str, ""))
+}
+
+// Truncate shortens a string to fit within a specified visual width, optionally
+// appending a suffix (e.g., "..."). It preserves ANSI escape sequences and adds
+// a reset sequence (\x1b[0m) if needed to prevent formatting bleed. The function
+// respects the global East Asian width setting and is thread-safe.
+//
+// If maxWidth is negative, an empty string is returned. If maxWidth is zero and
+// a suffix is provided, the suffix is returned. If the string's visual width is
+// less than or equal to maxWidth, the string (and suffix, if provided and fits)
+// is returned unchanged.
+//
+// Example:
+//
+//	s := twdw.Truncate("Hello\x1b[31mWorld", 5, "...") // Returns "Hello..."
+//	s = twdw.Truncate("Hello", 10) // Returns "Hello"
+func Truncate(s string, maxWidth int, suffix ...string) string {
+	if maxWidth < 0 {
+		return ""
+	}
+
+	suffixStr := strings.Join(suffix, "")
+	sDisplayWidth := Width(s)              // Uses global cached Width
+	suffixDisplayWidth := Width(suffixStr) // Uses global cached Width
+
+	// Case 1: Original string is visually empty.
+	if sDisplayWidth == 0 {
+		// If suffix is provided and fits within maxWidth (or if maxWidth is generous)
+		if len(suffixStr) > 0 && suffixDisplayWidth <= maxWidth {
+			return suffixStr
+		}
+		// If s has ANSI codes (len(s)>0) but maxWidth is 0, can't display them.
+		if maxWidth == 0 && len(s) > 0 {
+			return ""
+		}
+		return s // Returns "" or original ANSI codes
+	}
+
+	// Case 2: maxWidth is 0, but string has content. Cannot display anything.
+	if maxWidth == 0 {
+		return ""
+	}
+
+	// Case 3: String fits completely or fits with suffix.
+	// Here, maxWidth is the total budget for the line.
+	if sDisplayWidth <= maxWidth {
+		if len(suffixStr) == 0 { // No suffix.
+			return s
+		}
+		// Suffix is provided. Check if s + suffix fits.
+		if sDisplayWidth+suffixDisplayWidth <= maxWidth {
+			return s + suffixStr
+		}
+		// s fits, but s + suffix is too long. Return s.
+		return s
+	}
+
+	// Case 4: String needs truncation (sDisplayWidth > maxWidth).
+	// maxWidth is the total budget for the final string (content + suffix).
+
+	// Capture the global EastAsianWidth setting once for consistent use
+	mu.Lock()
+	currentGlobalEastAsianWidth := condition.EastAsianWidth
+	mu.Unlock()
+
+	// Special case for EastAsian true: if only suffix fits, return suffix.
+	// This was derived from previous test behavior.
+	if len(suffixStr) > 0 && currentGlobalEastAsianWidth {
+		provisionalContentWidth := maxWidth - suffixDisplayWidth
+		if provisionalContentWidth == 0 { // Exactly enough space for suffix only
+			return suffixStr // <<<< MODIFIED: No ANSI reset here
+		}
+	}
+
+	// Calculate the budget for the content part, reserving space for the suffix.
+	targetContentForIteration := maxWidth
+	if len(suffixStr) > 0 {
+		targetContentForIteration -= suffixDisplayWidth
+	}
+
+	// If content budget is negative, means not even suffix fits (or no suffix and no space).
+	// However, if only suffix fits, it should be handled.
+	if targetContentForIteration < 0 {
+		// Can we still fit just the suffix?
+		if len(suffixStr) > 0 && suffixDisplayWidth <= maxWidth {
+			if strings.Contains(s, "\x1b[") {
+				return "\x1b[0m" + suffixStr
+			}
+			return suffixStr
+		}
+		return "" // Cannot fit anything.
+	}
+	// If targetContentForIteration is 0, loop won't run, result will be empty string, then suffix is added.
+
+	var contentBuf bytes.Buffer
+	var currentContentDisplayWidth int
+	var ansiSeqBuf bytes.Buffer
+	inAnsiSequence := false
+	ansiWrittenToContent := false
+
+	localRunewidthCond := runewidth.NewCondition()
+	localRunewidthCond.EastAsianWidth = currentGlobalEastAsianWidth
+
+	for _, r := range s {
+		if r == '\x1b' {
+			inAnsiSequence = true
+			ansiSeqBuf.Reset()
+			ansiSeqBuf.WriteRune(r)
+		} else if inAnsiSequence {
+			ansiSeqBuf.WriteRune(r)
+			seqBytes := ansiSeqBuf.Bytes()
+			seqLen := len(seqBytes)
+			terminated := false
+			if seqLen >= 2 {
+				introducer := seqBytes[1]
+				if introducer == '[' {
+					if seqLen >= 3 && r >= 0x40 && r <= 0x7E {
+						terminated = true
+					}
+				} else if introducer == ']' {
+					if r == '\x07' {
+						terminated = true
+					} else if seqLen > 1 && seqBytes[seqLen-2] == '\x1b' && r == '\\' { // Check for ST: \x1b\
+						terminated = true
+					}
+				}
+			}
+			if terminated {
+				inAnsiSequence = false
+				contentBuf.Write(ansiSeqBuf.Bytes())
+				ansiWrittenToContent = true
+				ansiSeqBuf.Reset()
+			}
+		} else { // Normal character
+			runeDisplayWidth := localRunewidthCond.RuneWidth(r)
+			if targetContentForIteration == 0 { // No budget for content at all
+				break
+			}
+			if currentContentDisplayWidth+runeDisplayWidth > targetContentForIteration {
+				break
+			}
+			contentBuf.WriteRune(r)
+			currentContentDisplayWidth += runeDisplayWidth
+		}
+	}
+
+	result := contentBuf.String()
+
+	// Suffix is added if:
+	// 1. A suffix string is provided.
+	// 2. Truncation actually happened (sDisplayWidth > maxWidth originally)
+	//    OR if the content part is empty but a suffix is meant to be shown
+	//    (e.g. targetContentForIteration was 0).
+	if len(suffixStr) > 0 {
+		// Add suffix if we are in the truncation path (sDisplayWidth > maxWidth)
+		// OR if targetContentForIteration was 0 (meaning only suffix should be shown)
+		// but we must ensure we don't exceed original maxWidth.
+		// The logic above for targetContentForIteration already ensures space.
+
+		needsReset := false
+		// Condition for reset: if styling was active in 's' and might affect suffix
+		if (ansiWrittenToContent || (inAnsiSequence && strings.Contains(s, "\x1b["))) && (currentContentDisplayWidth > 0 || ansiWrittenToContent) {
+			if !strings.HasSuffix(result, "\x1b[0m") {
+				needsReset = true
+			}
+		} else if currentContentDisplayWidth > 0 && strings.Contains(result, "\x1b[") && !strings.HasSuffix(result, "\x1b[0m") && strings.Contains(s, "\x1b[") {
+			// If result has content and ANSI, and original had ANSI, and result not already reset
+			needsReset = true
+		}
+
+		if needsReset {
+			result += "\x1b[0m"
+		}
+		result += suffixStr
+	}
+	return result
+}

--- a/pkg/twwidth/width_test.go
+++ b/pkg/twwidth/width_test.go
@@ -1,0 +1,391 @@
+package twwidth
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mattn/go-runewidth"
+)
+
+func TestMain(m *testing.M) {
+	mu.Lock()
+	condition = runewidth.NewCondition()
+	mu.Unlock()
+	os.Exit(m.Run())
+}
+
+func TestFilter(t *testing.T) {
+	ansi := Filter()
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"\033[31m", true},
+		{"\033]8;;http://example.com\007", true},
+		{"hello", false},
+		{"\033[m", true},
+		{"\033[1;34;40m", true},
+		{"\033invalid", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := ansi.MatchString(tt.input); got != tt.expected {
+				t.Errorf("Filter().MatchString(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSetEastAsian(t *testing.T) {
+	original := condition.EastAsianWidth
+	SetEastAsian(true)
+	if !condition.EastAsianWidth {
+		t.Errorf("SetEastAsian(true): condition.EastAsianWidth = false, want true")
+	}
+	SetEastAsian(false)
+	if condition.EastAsianWidth {
+		t.Errorf("SetEastAsian(false): condition.EastAsianWidth = true, want false")
+	}
+	mu.Lock()
+	condition.EastAsianWidth = original
+	mu.Unlock()
+}
+
+func TestWidth(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		eastAsian     bool
+		expectedWidth int
+	}{
+		{
+			name:          "ASCII",
+			input:         "hello",
+			eastAsian:     false,
+			expectedWidth: 5,
+		},
+		{
+			name:          "Unicode with ANSI",
+			input:         "\033[31m☆あ\033[0m",
+			eastAsian:     false,
+			expectedWidth: 3,
+		},
+		{
+			name:          "Unicode with EastAsian",
+			input:         "\033[31m☆あ\033[0m",
+			eastAsian:     true,
+			expectedWidth: 4,
+		},
+		{
+			name:          "Empty string",
+			input:         "",
+			eastAsian:     false,
+			expectedWidth: 0,
+		},
+		{
+			name:          "Only ANSI",
+			input:         "\033[31m\033[0m",
+			eastAsian:     false,
+			expectedWidth: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetEastAsian(tt.eastAsian)
+			got := Width(tt.input)
+			if got != tt.expectedWidth {
+				t.Errorf("Width(%q) = %d, want %d (EastAsian=%v)", tt.input, got, tt.expectedWidth, tt.eastAsian)
+			}
+		})
+	}
+}
+
+func TestDisplay(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		eastAsian     bool
+		expectedWidth int
+	}{
+		{
+			name:          "ASCII",
+			input:         "hello",
+			eastAsian:     false,
+			expectedWidth: 5,
+		},
+		{
+			name:          "Unicode with ANSI",
+			input:         "\033[31m☆あ\033[0m",
+			eastAsian:     false,
+			expectedWidth: 3,
+		},
+		{
+			name:          "Unicode with EastAsian",
+			input:         "\033[31m☆あ\033[0m",
+			eastAsian:     true,
+			expectedWidth: 4,
+		},
+		{
+			name:          "Empty string",
+			input:         "",
+			eastAsian:     false,
+			expectedWidth: 0,
+		},
+		{
+			name:          "Only ANSI",
+			input:         "\033[31m\033[0m",
+			eastAsian:     false,
+			expectedWidth: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cond := &runewidth.Condition{EastAsianWidth: tt.eastAsian}
+			got := Display(cond, tt.input)
+			if got != tt.expectedWidth {
+				t.Errorf("Display(%q, cond) = %d, want %d (EastAsian=%v)", tt.input, got, tt.expectedWidth, tt.eastAsian)
+			}
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		maxWidth  int // This is now totalBudgetForOutput
+		suffix    []string
+		eastAsian bool
+		expected  string
+	}{
+		{
+			name:      "ASCII within width", // sDisplayWidth (5) <= maxWidth (5). No suffix.
+			input:     "hello",
+			maxWidth:  5,
+			suffix:    nil,
+			eastAsian: false,
+			expected:  "hello", // CORRECT - No change.
+		},
+		{
+			name:      "ASCII with suffix", // sDisplayWidth (5) + suffixWidth (3) = 8. maxWidth (8).
+			input:     "hello",             // sDisplayWidth (5) <= maxWidth (8) is true.
+			maxWidth:  8,                   // Then check sDisplayWidth+suffixDisplayWidth <= maxWidth (5+3 <= 8), true.
+			suffix:    []string{"..."},
+			eastAsian: false,
+			expected:  "hello...", // CORRECT - No change.
+		},
+		{
+			name:      "ASCII truncate", // sDisplayWidth (5) > maxWidth (3). Truncation needed.
+			input:     "hello",
+			maxWidth:  3,               // totalBudgetForOutput = 3
+			suffix:    []string{"..."}, // suffixWidth = 3
+			eastAsian: false,
+			// New behavior: contentBudget = 3 - 3 = 0.
+			// Truncate "hello" to width 0 -> "".
+			// Append "..." -> "...".
+			expected: "...", // <<<< CHANGED from "hel..."
+		},
+		{
+			name:      "Unicode with ANSI, no truncate", // sDisplayWidth (3) <= maxWidth (3). No suffix.
+			input:     "\033[31m☆あ\033[0m",
+			maxWidth:  3,
+			suffix:    nil,
+			eastAsian: false,
+			expected:  "\033[31m☆あ\033[0m", // CORRECT - No change.
+		},
+		{
+			name:      "Unicode with ANSI, truncate", // sDisplayWidth (3) > maxWidth (2). Truncation needed.
+			input:     "\033[31m☆あ\033[0m",           // ☆ (1), あ (2 with EA=false) -> width 3.
+			maxWidth:  2,                             // totalBudgetForOutput = 2
+			suffix:    []string{"..."},               // suffixWidth = 3
+			eastAsian: false,
+			// New behavior: contentBudget = 2 - 3 = -1.
+			// Since contentBudget < 0, check if suffix fits: suffixWidth (3) > maxWidth (2) -> No.
+			// Returns "".
+			expected: "", // <<<< CHANGED from "\033[31m☆\033[0m..."
+			// OLD logic: content budget = 2. Truncated to ☆ (width 1). Added ... -> ☆...
+			// The previous logic might have been flawed if `maxWidth` was for content only.
+			// If the old `expected` was correct, it implied `maxWidth=2` was budget for content, making output `☆...` width `1+3=4`.
+			// With new logic, if `maxWidth=2` is total, and suffix is `...` (width 3), can't fit.
+			// Let's re-evaluate: if `maxWidth` is total budget for output, including suffix.
+			// `input`="☆あ" (width ☆=1, あ=2 -> total 3 if EA=false, or ☆=1, あ=1 -> total 2 if not counting `runewidth` on `あ` correctly)
+			// Assuming ☆=1, あ=1 for EA=false based on original tests. So input width = 2.
+			// If input width = 2 and maxWidth = 2, it should fit as `\033[31m☆あ\033[0m`.
+			// Let's use the Width function values: input="\033[31m☆あ\033[0m", EA=false -> Width = 3. (☆=1, あ=2 if `runewidth` default)
+			// Okay, Width("☆あ", EA=false) = 3 (☆=1, あ=2).
+			// sDisplayWidth (3) > maxWidth (2). Truncation.
+			// contentBudget = 2 (maxWidth) - 3 (suffixWidth) = -1.
+			// Can suffix fit? suffixWidth (3) not <= maxWidth (2). So, return "". This is correct under new rule.
+		},
+		{
+			name:      "Unicode with EastAsian", // sDisplayWidth (4 with EA=true) > maxWidth (3). Truncation.
+			input:     "\033[31m☆あ\033[0m",      // ☆ (2), あ (2) -> width 4
+			maxWidth:  3,                        // totalBudgetForOutput = 3
+			suffix:    []string{"..."},          // suffixWidth = 3
+			eastAsian: true,
+			// New behavior: contentBudget = 3 - 3 = 0.
+			// Truncate to width 0 -> "".
+			// Append "..." -> "...".
+			// Also, there's the special EastAsian case: if currentGlobalEastAsianWidth is true,
+			// and provisionalContentWidth (maxWidth - suffixDisplayWidth) == 0, return suffixStr.
+			// Here, 3 - 3 == 0. So returns "..."
+			expected: "...", // CORRECT - This was already the expectation that drove a previous change.
+		},
+		{
+			name:      "Zero maxWidth", // maxWidth = 0.
+			input:     "hello",
+			maxWidth:  0,
+			suffix:    []string{"..."},
+			eastAsian: false,
+			expected:  "", // CORRECT - Truncate returns "" if maxWidth is 0 and sDisplayWidth > 0.
+		},
+		{
+			name:      "Negative maxWidth", // maxWidth = -1.
+			input:     "hello",
+			maxWidth:  -1,
+			suffix:    []string{"..."},
+			eastAsian: false,
+			expected:  "", // CORRECT - Truncate returns "" if maxWidth < 0.
+		},
+		{
+			name:      "Empty string with suffix", // sDisplayWidth = 0.
+			input:     "",
+			maxWidth:  3,
+			suffix:    []string{"..."}, // suffixWidth = 3.
+			eastAsian: false,
+			// Behavior: sDisplayWidth == 0. suffix exists. suffixWidth (3) <= maxWidth (3). Returns suffixStr.
+			expected: "...", // CORRECT.
+		},
+		{
+			name:      "Only ANSI", // sDisplayWidth = 0.
+			input:     "\033[31m\033[0m",
+			maxWidth:  3,
+			suffix:    []string{"..."}, // suffixWidth = 3.
+			eastAsian: false,
+			// Behavior: sDisplayWidth == 0. suffix exists. suffixWidth (3) <= maxWidth (3). Returns suffixStr.
+			expected: "...", // CORRECT.
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetEastAsian(tt.eastAsian) // This sets the global state for Width() calls inside Truncate
+			got := Truncate(tt.input, tt.maxWidth, tt.suffix...)
+			if got != tt.expected {
+				t.Errorf("Truncate(%q, %d, %v) (EA=%v) = %q, want %q", tt.input, tt.maxWidth, tt.suffix, tt.eastAsian, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConcurrentSetEastAsian(t *testing.T) {
+	var wg sync.WaitGroup
+	numGoroutines := 10
+	iterations := 100
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(enable bool) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				SetEastAsian(enable)
+			}
+		}(i%2 == 0)
+	}
+
+	wg.Wait()
+}
+
+func TestWidthWithEnvironment(t *testing.T) {
+	original := os.Getenv("RUNEWIDTH_EASTASIAN")
+	defer func() {
+		if original == "" {
+			os.Unsetenv("RUNEWIDTH_EASTASIAN")
+		} else {
+			os.Setenv("RUNEWIDTH_EASTASIAN", original)
+		}
+	}()
+
+	os.Setenv("RUNEWIDTH_EASTASIAN", "0")
+	SetEastAsian(false)
+	if got := Width("☆あ"); got != 3 {
+		t.Errorf("Width(☆あ) with RUNEWIDTH_EASTASIAN=0 = %d, want 3", got)
+	}
+
+	os.Setenv("RUNEWIDTH_EASTASIAN", "1")
+	SetEastAsian(true)
+	if got := Width("☆あ"); got != 4 {
+		t.Errorf("Width(☆あ) with RUNEWIDTH_EASTASIAN=1 = %d, want 4", got)
+	}
+}
+
+// Helper to reset the cache for a clean benchmark state
+func resetGlobalCache() {
+	mu.Lock()
+	widthCache = make(map[cacheKey]int)
+	mu.Unlock()
+}
+
+var benchmarkStrings = map[string]string{
+	"SimpleASCII":       "hello world, this is a test string.",
+	"ASCIIWithANSI":     "\033[31mhello\033[0m \033[34mworld\033[0m, this is \033[1ma\033[0m test string.",
+	"EastAsian":         "こんにちは世界、これはテスト文字列です。",
+	"EastAsianWithANSI": "\033[32mこんにちは\033[0m \033[35m世界\033[0m、これは\033[4mテスト\033[0m文字列です。",
+	"LongSimpleASCII":   strings.Repeat("abcdefghijklmnopqrstuvwxyz ", 20),                                    // 27*20 = 540 chars
+	"LongASCIIWithANSI": strings.Repeat("\033[31ma\033[32mb\033[33mc\033[34md\033[35me\033[36mf\033[0m ", 50), // ~15*50 = 750 chars with ANSI
+}
+
+func BenchmarkWidthFunction(b *testing.B) {
+	eastAsianSettings := []bool{false, true}
+
+	for name, str := range benchmarkStrings {
+		for _, eaSetting := range eastAsianSettings {
+			// Ensure the global EastAsian setting is correct for the sub-benchmark
+			// SetEastAsian also clears the cache, which is good for starting fresh.
+			SetEastAsian(eaSetting)
+
+			// Benchmark: No Caching (using our internal non-cached version)
+			b.Run(fmt.Sprintf("%s_EA%v_NoCache", name, eaSetting), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					_ = WidthNoCache(str)
+				}
+			})
+
+			// Benchmark: Cached Version - Cache Misses
+			// We make strings unique to ensure cache misses.
+			// SetEastAsian above already cleared the cache.
+			b.Run(fmt.Sprintf("%s_EA%v_CacheMiss", name, eaSetting), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					// Make string unique for each iteration to force cache miss
+					_ = Width(str + strconv.Itoa(i))
+				}
+			})
+			resetGlobalCache() // Clear cache before the cache hit test
+
+			// Benchmark: Cached Version - Cache Hits
+			// First call populates, subsequent calls hit.
+			// SetEastAsian above (or resetGlobalCache) ensures cache is empty at start.
+			b.Run(fmt.Sprintf("%s_EA%v_CacheHit", name, eaSetting), func(b *testing.B) {
+				b.ReportAllocs()
+				// First call will populate the cache
+				if b.N > 0 {
+					_ = Width(str)
+				}
+				// Subsequent calls should hit the cache
+				for i := 1; i < b.N; i++ { // Start from 1 if first call is outside/setup
+					_ = Width(str)
+				}
+			})
+			resetGlobalCache() // Clean up for next iteration/test
+		}
+	}
+}

--- a/renderer/colorized.go
+++ b/renderer/colorized.go
@@ -4,6 +4,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/olekukonko/ll"
 	"github.com/olekukonko/ll/lh"
+	"github.com/olekukonko/tablewriter/pkg/twwidth"
 	"io"
 	"strings"
 
@@ -254,7 +255,7 @@ func (c *Colorized) Line(ctx tw.Formatting) {
 			line.WriteString(strings.Repeat(tw.Space, colWidth))
 		} else {
 			// Calculate how many times to repeat the segment
-			segmentWidth := tw.DisplayWidth(segment)
+			segmentWidth := twwidth.Width(segment)
 			if segmentWidth <= 0 {
 				segmentWidth = 1
 			}
@@ -266,7 +267,7 @@ func (c *Colorized) Line(ctx tw.Formatting) {
 			line.WriteString(drawnSegment)
 
 			// Adjust for width discrepancies
-			actualDrawnWidth := tw.DisplayWidth(drawnSegment)
+			actualDrawnWidth := twwidth.Width(drawnSegment)
 			if actualDrawnWidth < colWidth {
 				missingWidth := colWidth - actualDrawnWidth
 				spaces := strings.Repeat(tw.Space, missingWidth)
@@ -373,7 +374,7 @@ func (c *Colorized) formatCell(content string, width int, padding tw.Padding, al
 	}
 
 	// Calculate visual width of content
-	contentVisualWidth := tw.DisplayWidth(content)
+	contentVisualWidth := twwidth.Width(content)
 
 	// Set default padding characters
 	padLeftCharStr := padding.Left
@@ -386,8 +387,8 @@ func (c *Colorized) formatCell(content string, width int, padding tw.Padding, al
 	}
 
 	// Calculate padding widths
-	definedPadLeftWidth := tw.DisplayWidth(padLeftCharStr)
-	definedPadRightWidth := tw.DisplayWidth(padRightCharStr)
+	definedPadLeftWidth := twwidth.Width(padLeftCharStr)
+	definedPadRightWidth := twwidth.Width(padRightCharStr)
 	// Calculate available width for content and alignment
 	availableForContentAndAlign := width - definedPadLeftWidth - definedPadRightWidth
 	if availableForContentAndAlign < 0 {
@@ -396,8 +397,8 @@ func (c *Colorized) formatCell(content string, width int, padding tw.Padding, al
 
 	// Truncate content if it exceeds available width
 	if contentVisualWidth > availableForContentAndAlign {
-		content = tw.TruncateString(content, availableForContentAndAlign)
-		contentVisualWidth = tw.DisplayWidth(content)
+		content = twwidth.Truncate(content, availableForContentAndAlign)
+		contentVisualWidth = twwidth.Width(content)
 		c.logger.Debugf("Truncated content to fit %d: '%s' (new width %d)", availableForContentAndAlign, content, contentVisualWidth)
 	}
 
@@ -472,12 +473,12 @@ func (c *Colorized) formatCell(content string, width int, padding tw.Padding, al
 	output := sb.String()
 
 	// Adjust output width if necessary
-	currentVisualWidth := tw.DisplayWidth(output)
+	currentVisualWidth := twwidth.Width(output)
 	if currentVisualWidth != width {
 		c.logger.Debugf("formatCell MISMATCH: content='%s', target_w=%d. Calculated parts width = %d. String: '%s'",
 			content, width, currentVisualWidth, output)
 		if currentVisualWidth > width {
-			output = tw.TruncateString(output, width)
+			output = twwidth.Truncate(output, width)
 		} else {
 			paddingSpacesStr := strings.Repeat(tw.Space, width-currentVisualWidth)
 			if len(tint.BG) > 0 {
@@ -486,10 +487,10 @@ func (c *Colorized) formatCell(content string, width int, padding tw.Padding, al
 				output += paddingSpacesStr
 			}
 		}
-		c.logger.Debugf("formatCell Post-Correction: Target %d, New Visual width %d. Output: '%s'", width, tw.DisplayWidth(output), output)
+		c.logger.Debugf("formatCell Post-Correction: Target %d, New Visual width %d. Output: '%s'", width, twwidth.Width(output), output)
 	}
 
-	c.logger.Debugf("Formatted cell final result: '%s' (target width %d, display width %d)", output, width, tw.DisplayWidth(output))
+	c.logger.Debugf("Formatted cell final result: '%s' (target width %d, display width %d)", output, width, twwidth.Width(output))
 	return output
 }
 
@@ -529,7 +530,7 @@ func (c *Colorized) renderLine(ctx tw.Formatting, line []string, tint Tint) {
 	separatorString := tw.Empty
 	if c.config.Settings.Separators.BetweenColumns.Enabled() {
 		separatorString = c.config.Separator.Apply(c.config.Symbols.Column())
-		separatorDisplayWidth = tw.DisplayWidth(c.config.Symbols.Column())
+		separatorDisplayWidth = twwidth.Width(c.config.Symbols.Column())
 	}
 
 	// Process each column

--- a/renderer/markdown.go
+++ b/renderer/markdown.go
@@ -2,6 +2,7 @@ package renderer
 
 import (
 	"github.com/olekukonko/ll"
+	"github.com/olekukonko/tablewriter/pkg/twwidth"
 	"io"
 	"strings"
 
@@ -157,7 +158,7 @@ func (m *Markdown) formatCell(content string, width int, align tw.Align, padding
 	//if m.config.Settings.TrimWhitespace.Enabled() {
 	//	content = strings.TrimSpace(content)
 	//}
-	contentVisualWidth := tw.DisplayWidth(content)
+	contentVisualWidth := twwidth.Width(content)
 
 	// Use specified padding characters or default to spaces
 	padLeftChar := padding.Left
@@ -170,8 +171,8 @@ func (m *Markdown) formatCell(content string, width int, align tw.Align, padding
 	}
 
 	// Calculate padding widths
-	padLeftCharWidth := tw.DisplayWidth(padLeftChar)
-	padRightCharWidth := tw.DisplayWidth(padRightChar)
+	padLeftCharWidth := twwidth.Width(padLeftChar)
+	padRightCharWidth := twwidth.Width(padRightChar)
 	minWidth := tw.Max(3, contentVisualWidth+padLeftCharWidth+padRightCharWidth)
 	targetWidth := tw.Max(width, minWidth)
 
@@ -212,7 +213,7 @@ func (m *Markdown) formatCell(content string, width int, align tw.Align, padding
 	result := leftPadStr + content + rightPadStr
 
 	// Adjust width if needed
-	finalWidth := tw.DisplayWidth(result)
+	finalWidth := twwidth.Width(result)
 	if finalWidth != targetWidth {
 		m.logger.Debugf("Markdown formatCell MISMATCH: content='%s', target_w=%d, paddingL='%s', paddingR='%s', align=%s -> result='%s', result_w=%d",
 			content, targetWidth, padding.Left, padding.Right, align, result, finalWidth)
@@ -229,9 +230,9 @@ func (m *Markdown) formatCell(content string, width int, align tw.Align, padding
 				result += adjStr
 			}
 		} else {
-			result = tw.TruncateString(result, targetWidth)
+			result = twwidth.Truncate(result, targetWidth)
 		}
-		m.logger.Debugf("Markdown formatCell Corrected: target_w=%d, result='%s', new_w=%d", targetWidth, result, tw.DisplayWidth(result))
+		m.logger.Debugf("Markdown formatCell Corrected: target_w=%d, result='%s', new_w=%d", targetWidth, result, twwidth.Width(result))
 	}
 
 	m.logger.Debugf("Markdown formatCell: content='%s', width=%d, align=%s, paddingL='%s', paddingR='%s' -> '%s' (target %d)",
@@ -262,11 +263,11 @@ func (m *Markdown) formatSeparator(width int, align tw.Align) string {
 	}
 
 	result := sb.String()
-	currentLen := tw.DisplayWidth(result)
+	currentLen := twwidth.Width(result)
 	if currentLen < targetWidth {
 		result += strings.Repeat("-", targetWidth-currentLen)
 	} else if currentLen > targetWidth {
-		result = tw.TruncateString(result, targetWidth)
+		result = twwidth.Truncate(result, targetWidth)
 	}
 
 	m.logger.Debugf("Markdown formatSeparator: width=%d, align=%s -> '%s'", width, align, result)
@@ -314,7 +315,7 @@ func (m *Markdown) renderMarkdownLine(line []string, ctx tw.Formatting, isHeader
 	output.WriteString(prefix)
 
 	colIndex := 0
-	separatorWidth := tw.DisplayWidth(separator)
+	separatorWidth := twwidth.Width(separator)
 
 	for colIndex < numCols {
 		cellCtx, ok := ctx.Row.Current[colIndex]

--- a/renderer/ocean.go
+++ b/renderer/ocean.go
@@ -1,6 +1,7 @@
 package renderer
 
 import (
+	"github.com/olekukonko/tablewriter/pkg/twwidth"
 	"io"
 	"strings"
 
@@ -262,7 +263,7 @@ func (o *Ocean) Line(ctx tw.Formatting) {
 			if segmentChar == tw.Empty {
 				segmentChar = o.config.Symbols.Row()
 			}
-			segmentDisplayWidth := tw.DisplayWidth(segmentChar)
+			segmentDisplayWidth := twwidth.Width(segmentChar)
 			if segmentDisplayWidth <= 0 {
 				segmentDisplayWidth = 1
 			}
@@ -374,7 +375,7 @@ func (o *Ocean) renderContentLine(ctx tw.Formatting, lineData []string) {
 					}
 
 					if k < hSpan-1 && o.config.Settings.Separators.BetweenColumns.Enabled() {
-						currentMergeTotalRenderWidth += tw.DisplayWidth(o.config.Symbols.Column())
+						currentMergeTotalRenderWidth += twwidth.Width(o.config.Symbols.Column())
 					}
 				}
 				actualCellWidthToRender = currentMergeTotalRenderWidth
@@ -428,7 +429,7 @@ func (o *Ocean) formatCellContent(content string, cellVisualWidth int, padding t
 		return tw.Empty
 	}
 
-	contentDisplayWidth := tw.DisplayWidth(content)
+	contentDisplayWidth := twwidth.Width(content)
 
 	padLeftChar := padding.Left
 	if padLeftChar == tw.Empty {
@@ -439,8 +440,8 @@ func (o *Ocean) formatCellContent(content string, cellVisualWidth int, padding t
 		padRightChar = tw.Space
 	}
 
-	padLeftDisplayWidth := tw.DisplayWidth(padLeftChar)
-	padRightDisplayWidth := tw.DisplayWidth(padRightChar)
+	padLeftDisplayWidth := twwidth.Width(padLeftChar)
+	padRightDisplayWidth := twwidth.Width(padRightChar)
 
 	spaceForContentAndAlignment := cellVisualWidth - padLeftDisplayWidth - padRightDisplayWidth
 	if spaceForContentAndAlignment < 0 {
@@ -448,8 +449,8 @@ func (o *Ocean) formatCellContent(content string, cellVisualWidth int, padding t
 	}
 
 	if contentDisplayWidth > spaceForContentAndAlignment {
-		content = tw.TruncateString(content, spaceForContentAndAlignment)
-		contentDisplayWidth = tw.DisplayWidth(content)
+		content = twwidth.Truncate(content, spaceForContentAndAlignment)
+		contentDisplayWidth = twwidth.Width(content)
 	}
 
 	remainingSpace := spaceForContentAndAlignment - contentDisplayWidth
@@ -477,7 +478,7 @@ func (o *Ocean) formatCellContent(content string, cellVisualWidth int, padding t
 	sb.WriteString(PR)
 	sb.WriteString(padRightChar)
 
-	currentFormattedWidth := tw.DisplayWidth(sb.String())
+	currentFormattedWidth := twwidth.Width(sb.String())
 	if currentFormattedWidth < cellVisualWidth {
 		if align == tw.AlignRight {
 			prefixSpaces := strings.Repeat(tw.Space, cellVisualWidth-currentFormattedWidth)
@@ -490,7 +491,7 @@ func (o *Ocean) formatCellContent(content string, cellVisualWidth int, padding t
 	} else if currentFormattedWidth > cellVisualWidth {
 		tempStr := sb.String()
 		sb.Reset()
-		sb.WriteString(tw.TruncateString(tempStr, cellVisualWidth))
+		sb.WriteString(twwidth.Truncate(tempStr, cellVisualWidth))
 		o.logger.Warnf("formatCellContent: Final string '%s' (width %d) exceeded target %d. Force truncated.", tempStr, currentFormattedWidth, cellVisualWidth)
 	}
 	return sb.String()

--- a/stream.go
+++ b/stream.go
@@ -3,6 +3,7 @@ package tablewriter
 import (
 	"fmt"
 	"github.com/olekukonko/errors"
+	"github.com/olekukonko/tablewriter/pkg/twwidth"
 	"github.com/olekukonko/tablewriter/tw"
 	"math"
 )
@@ -511,7 +512,7 @@ func (t *Table) streamCalculateWidths(sampling []string, config tw.CellConfig) i
 
 		ellipsisWidthBuffer := 0
 		if autoWrapForWidthCalc == tw.WrapTruncate {
-			ellipsisWidthBuffer = tw.DisplayWidth(tw.CharEllipsis)
+			ellipsisWidthBuffer = twwidth.Width(tw.CharEllipsis)
 		}
 		varianceBuffer := 2 // Your suggested variance
 		minTotalColWidth := tw.MinimumColumnWidth
@@ -525,14 +526,14 @@ func (t *Table) streamCalculateWidths(sampling []string, config tw.CellConfig) i
 			if i < len(sampling) {
 				sampleContent = t.Trimmer(sampling[i])
 			}
-			sampleContentDisplayWidth := tw.DisplayWidth(sampleContent)
+			sampleContentDisplayWidth := twwidth.Width(sampleContent)
 
 			colPad := paddingForWidthCalc.Global
 			if i < len(paddingForWidthCalc.PerColumn) && paddingForWidthCalc.PerColumn[i].Paddable() {
 				colPad = paddingForWidthCalc.PerColumn[i]
 			}
-			currentPadLWidth := tw.DisplayWidth(colPad.Left)
-			currentPadRWidth := tw.DisplayWidth(colPad.Right)
+			currentPadLWidth := twwidth.Width(colPad.Left)
+			currentPadRWidth := twwidth.Width(colPad.Right)
 			currentTotalPaddingWidth := currentPadLWidth + currentPadRWidth
 
 			// Start with the target content width logic
@@ -595,7 +596,7 @@ func (t *Table) streamCalculateWidths(sampling []string, config tw.CellConfig) i
 		if t.renderer != nil {
 			rendererConfig := t.renderer.Config()
 			if rendererConfig.Settings.Separators.BetweenColumns.Enabled() {
-				separatorWidth = tw.DisplayWidth(rendererConfig.Symbols.Column())
+				separatorWidth = twwidth.Width(rendererConfig.Symbols.Column())
 			}
 		} else {
 			separatorWidth = 1 // Default if renderer not available yet

--- a/tablewriter.go
+++ b/tablewriter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/olekukonko/ll"
 	"github.com/olekukonko/ll/lh"
 	"github.com/olekukonko/tablewriter/pkg/twwarp"
+	"github.com/olekukonko/tablewriter/pkg/twwidth"
 	"github.com/olekukonko/tablewriter/renderer"
 	"github.com/olekukonko/tablewriter/tw"
 	"io"
@@ -762,7 +763,7 @@ func (t *Table) printTopBottomCaption(w io.Writer, actualTableWidth int) {
 		captionWrapWidth = t.caption.Width
 		t.logger.Debugf("[printCaption] Using user-defined caption.Width %d for wrapping.", captionWrapWidth)
 	} else if actualTableWidth <= 4 {
-		captionWrapWidth = tw.DisplayWidth(t.caption.Text)
+		captionWrapWidth = twwidth.Width(t.caption.Text)
 		t.logger.Debugf("[printCaption] Empty table, no user caption.Width: Using natural caption width %d.", captionWrapWidth)
 	} else {
 		captionWrapWidth = actualTableWidth
@@ -885,8 +886,8 @@ func (t *Table) prepareContent(cells []string, config tw.CellConfig) [][]string 
 			colPad = config.Padding.PerColumn[i]
 		}
 
-		padLeftWidth := tw.DisplayWidth(colPad.Left)
-		padRightWidth := tw.DisplayWidth(colPad.Right)
+		padLeftWidth := twwidth.Width(colPad.Left)
+		padRightWidth := twwidth.Width(colPad.Right)
 
 		effectiveContentMaxWidth := t.calculateContentMaxWidth(i, config, padLeftWidth, padRightWidth, isStreaming)
 
@@ -908,12 +909,12 @@ func (t *Table) prepareContent(cells []string, config tw.CellConfig) [][]string 
 					}
 					finalLinesForCell = append(finalLinesForCell, wrapped...)
 				case tw.WrapTruncate:
-					if tw.DisplayWidth(line) > effectiveContentMaxWidth {
-						ellipsisWidth := tw.DisplayWidth(tw.CharEllipsis)
+					if twwidth.Width(line) > effectiveContentMaxWidth {
+						ellipsisWidth := twwidth.Width(tw.CharEllipsis)
 						if effectiveContentMaxWidth >= ellipsisWidth {
-							finalLinesForCell = append(finalLinesForCell, tw.TruncateString(line, effectiveContentMaxWidth-ellipsisWidth, tw.CharEllipsis))
+							finalLinesForCell = append(finalLinesForCell, twwidth.Truncate(line, effectiveContentMaxWidth-ellipsisWidth, tw.CharEllipsis))
 						} else {
-							finalLinesForCell = append(finalLinesForCell, tw.TruncateString(line, effectiveContentMaxWidth, ""))
+							finalLinesForCell = append(finalLinesForCell, twwidth.Truncate(line, effectiveContentMaxWidth, ""))
 						}
 					} else {
 						finalLinesForCell = append(finalLinesForCell, line)
@@ -921,8 +922,8 @@ func (t *Table) prepareContent(cells []string, config tw.CellConfig) [][]string 
 				case tw.WrapBreak:
 					wrapped := make([]string, 0)
 					currentLine := line
-					breakCharWidth := tw.DisplayWidth(tw.CharBreak)
-					for tw.DisplayWidth(currentLine) > effectiveContentMaxWidth {
+					breakCharWidth := twwidth.Width(tw.CharBreak)
+					for twwidth.Width(currentLine) > effectiveContentMaxWidth {
 						targetWidth := effectiveContentMaxWidth - breakCharWidth
 						if targetWidth < 0 {
 							targetWidth = 0
@@ -935,7 +936,7 @@ func (t *Table) prepareContent(cells []string, config tw.CellConfig) [][]string 
 							tempWidth := 0
 							for charIdx, r := range runes {
 								runeStr := string(r)
-								rw := tw.DisplayWidth(runeStr)
+								rw := twwidth.Width(runeStr)
 								if tempWidth+rw > targetWidth && charIdx > 0 {
 									break
 								}
@@ -962,10 +963,10 @@ func (t *Table) prepareContent(cells []string, config tw.CellConfig) [][]string 
 							currentLine = string(runes[breakPoint:])
 						}
 					}
-					if tw.DisplayWidth(currentLine) > 0 {
+					if twwidth.Width(currentLine) > 0 {
 						wrapped = append(wrapped, currentLine)
 					}
-					if len(wrapped) == 0 && tw.DisplayWidth(line) > 0 && len(finalLinesForCell) == 0 {
+					if len(wrapped) == 0 && twwidth.Width(line) > 0 && len(finalLinesForCell) == 0 {
 						finalLinesForCell = append(finalLinesForCell, line)
 					} else {
 						finalLinesForCell = append(finalLinesForCell, wrapped...)
@@ -1447,7 +1448,7 @@ func (t *Table) render() error {
 		actualTableWidth := 0
 		trimmedBuffer := strings.TrimRight(renderedTableContent, "\r\n \t")
 		for _, line := range strings.Split(trimmedBuffer, "\n") {
-			w := tw.DisplayWidth(line)
+			w := twwidth.Width(line)
 			if w > actualTableWidth {
 				actualTableWidth = w
 			}
@@ -1719,7 +1720,7 @@ func (t *Table) renderFooter(ctx *renderContext, mctx *mergeContext) error {
 			if j == 0 || representativePadChar == " " {
 				representativePadChar = padChar
 			}
-			padWidth := tw.DisplayWidth(padChar)
+			padWidth := twwidth.Width(padChar)
 			if padWidth < 1 {
 				padWidth = 1
 			}
@@ -1734,12 +1735,12 @@ func (t *Table) renderFooter(ctx *renderContext, mctx *mergeContext) error {
 				repeatCount = 0
 			}
 			rawPaddingContent := strings.Repeat(padChar, repeatCount)
-			currentWd := tw.DisplayWidth(rawPaddingContent)
+			currentWd := twwidth.Width(rawPaddingContent)
 			if currentWd < colWd {
 				rawPaddingContent += strings.Repeat(" ", colWd-currentWd)
 			}
 			if currentWd > colWd && colWd > 0 {
-				rawPaddingContent = tw.TruncateString(rawPaddingContent, colWd)
+				rawPaddingContent = twwidth.Truncate(rawPaddingContent, colWd)
 			}
 			if colWd == 0 {
 				rawPaddingContent = ""

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -352,10 +352,9 @@ func TestLongHeaders(t *testing.T) {
 			},
 				ColMaxWidths: tw.CellWidth{Global: 30},
 			},
-			Debug: false,
 		}
 		buf.Reset()
-		table := tablewriter.NewTable(&buf, tablewriter.WithConfig(c), tablewriter.WithDebug(false))
+		table := tablewriter.NewTable(&buf, tablewriter.WithConfig(c), tablewriter.WithDebug(true))
 		table.Header([]string{"Name", "Age", "This is a very long header, let see if this will be properly wrapped"})
 		table.Append([]string{"Alice", "25", "New York"})
 		table.Append([]string{"Bob", "30", "Boston"})

--- a/zoo.go
+++ b/zoo.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/olekukonko/errors"
+	"github.com/olekukonko/tablewriter/pkg/twwidth"
 	"github.com/olekukonko/tablewriter/tw"
 	"io"
 	"math"
@@ -165,7 +166,7 @@ func (t *Table) applyHorizontalMergeWidths(position tw.Position, ctx *renderCont
 	if t.renderer != nil {
 		rendererConfig := t.renderer.Config()
 		if rendererConfig.Settings.Separators.BetweenColumns.Enabled() {
-			separatorWidth = tw.DisplayWidth(rendererConfig.Symbols.Column())
+			separatorWidth = twwidth.Width(rendererConfig.Symbols.Column())
 		}
 	}
 
@@ -541,7 +542,7 @@ func (t *Table) buildCoreCellContexts(line []string, merges map[int]tw.MergeStat
 // It generates a []string where each element is the padding content for a column, using the specified padChar.
 func (t *Table) buildPaddingLineContents(padChar string, widths tw.Mapper[int, int], numCols int, merges map[int]tw.MergeState) []string {
 	line := make([]string, numCols)
-	padWidth := tw.DisplayWidth(padChar)
+	padWidth := twwidth.Width(padChar)
 	if padWidth < 1 {
 		padWidth = 1
 	}
@@ -715,15 +716,15 @@ func (t *Table) calculateAndNormalizeWidths(ctx *renderContext) error {
 			if 0 < len(t.config.Header.Padding.PerColumn) && t.config.Header.Padding.PerColumn[0].Paddable() {
 				headerCellPadding = t.config.Header.Padding.PerColumn[0]
 			}
-			actualMergedHeaderContentPhysicalWidth := tw.DisplayWidth(mergedContentString) +
-				tw.DisplayWidth(headerCellPadding.Left) +
-				tw.DisplayWidth(headerCellPadding.Right)
+			actualMergedHeaderContentPhysicalWidth := twwidth.Width(mergedContentString) +
+				twwidth.Width(headerCellPadding.Left) +
+				twwidth.Width(headerCellPadding.Right)
 			currentSumOfColumnWidths := 0
 			workingWidths.Each(func(_ int, w int) { currentSumOfColumnWidths += w })
 			numSeparatorsInFullSpan := 0
 			if ctx.numCols > 1 {
 				if t.renderer != nil && t.renderer.Config().Settings.Separators.BetweenColumns.Enabled() {
-					numSeparatorsInFullSpan = (ctx.numCols - 1) * tw.DisplayWidth(t.renderer.Config().Symbols.Column())
+					numSeparatorsInFullSpan = (ctx.numCols - 1) * twwidth.Width(t.renderer.Config().Symbols.Column())
 				}
 			}
 			totalCurrentSpanPhysicalWidth := currentSumOfColumnWidths + numSeparatorsInFullSpan
@@ -784,7 +785,7 @@ func (t *Table) calculateAndNormalizeWidths(ctx *renderContext) error {
 		finalWidths.Each(func(_ int, w int) { currentSumOfFinalColWidths += w })
 		numSeparators := 0
 		if ctx.numCols > 1 && t.renderer != nil && t.renderer.Config().Settings.Separators.BetweenColumns.Enabled() {
-			numSeparators = (ctx.numCols - 1) * tw.DisplayWidth(t.renderer.Config().Symbols.Column())
+			numSeparators = (ctx.numCols - 1) * twwidth.Width(t.renderer.Config().Symbols.Column())
 		}
 		totalCurrentTablePhysicalWidth := currentSumOfFinalColWidths + numSeparators
 		if totalCurrentTablePhysicalWidth > t.config.Widths.Global {
@@ -1655,16 +1656,16 @@ func (t *Table) updateWidths(row []string, widths tw.Mapper[int, int], padding t
 			t.logger.Debugf("  Col %d: Using global padding: L:'%s' R:'%s'", i, padding.Global.Left, padding.Global.Right)
 		}
 
-		padLeftWidth := tw.DisplayWidth(colPad.Left)
-		padRightWidth := tw.DisplayWidth(colPad.Right)
+		padLeftWidth := twwidth.Width(colPad.Left)
+		padRightWidth := twwidth.Width(colPad.Right)
 
 		// Split cell into lines and find maximum content width
 		lines := strings.Split(cell, tw.NewLine)
 		contentWidth := 0
 		for _, line := range lines {
-			lineWidth := tw.DisplayWidth(line)
+			lineWidth := twwidth.Width(line)
 			if t.config.Behavior.TrimSpace.Enabled() {
-				lineWidth = tw.DisplayWidth(t.Trimmer(line))
+				lineWidth = twwidth.Width(t.Trimmer(line))
 			}
 			if lineWidth > contentWidth {
 				contentWidth = lineWidth


### PR DESCRIPTION
This update introduces a more flexible and comprehensive approach to managing **EastAsianWidth**. Instead of relying solely on the default global configuration from the `runewidth` package, we now define our own **custom condition**, giving us greater control.

```go
// condition holds the global runewidth configuration, including East Asian width settings.
var condition *runewidth.Condition
```

By decoupling from the default `runewidth` condition, we gain the ability to fine-tune width calculations on a per-table basis. This change enables more precise behavior under specific display conditions, and supports functionality like:

```go
func WithEastAsian(enable bool) Option {
	return func(target *Table) {
		twwidth.SetEastAsian(enable)
	}
}
```

This modification allows us to dynamically influence how the system calculates string widths, which is particularly important when rendering tables with mixed-width characters (e.g., East Asian full-width characters). It also lays the groundwork for forcing specific widths under controlled conditions.

### References 

- https://github.com/olekukonko/tablewriter/issues/275
