### PR TITLE
Fixed typo of const value

### DIFF
--- a/tw/tw.go
+++ b/tw/tw.go
@@ -56,7 +56,7 @@ const (
 )
 
 const (
-	SectionHeader = "heder"
+	SectionHeader = "header"
 	SectionRow    = "row"
 	SectionFooter = "footer"
 )


### PR DESCRIPTION
The value of const was typo "heder" so fixed to "header".
Although, there is no damage/risk because of this typo.
Fix or retain, either is fine.