### PR TITLE
add both an option and ConfigBuilder func for AutoHeader for structs

### DIFF
--- a/config.go
+++ b/config.go
@@ -92,6 +92,12 @@ func (b *ConfigBuilder) WithAutoHide(state tw.State) *ConfigBuilder {
 	return b
 }
 
+// WithStructsAutoHeader enables/disables automatic header extraction for structs in Bulk.
+func (b *ConfigBuilder) WithStructsAutoHeader(state tw.State) *ConfigBuilder {
+	b.config.Behavior.Structs.AutoHeader = state
+	return b
+}
+
 // WithFooterAlignment sets the text alignment for all footer cells.
 // Invalid alignments are ignored.
 func (b *ConfigBuilder) WithFooterAlignment(align tw.Align) *ConfigBuilder {

--- a/option.go
+++ b/option.go
@@ -1,11 +1,13 @@
 package tablewriter
 
 import (
+	"reflect"
+
 	"github.com/mattn/go-runewidth"
 	"github.com/olekukonko/ll"
+
 	"github.com/olekukonko/tablewriter/pkg/twwidth"
 	"github.com/olekukonko/tablewriter/tw"
-	"reflect"
 )
 
 // Option defines a function type for configuring a Table instance.
@@ -505,6 +507,17 @@ func WithHeaderAutoFormat(state tw.State) Option {
 		target.config.Header.Formatting.AutoFormat = state
 		if target.logger != nil {
 			target.logger.Debugf("Option: WithHeaderAutoFormat applied to Table: %v", state)
+		}
+	}
+}
+
+// WithStructsAutoHeader enables/disables automatic header extraction for structs in Bulk.
+// Logs the change if debugging is enabled.
+func WithStructsAutoHeader(state tw.State) Option {
+	return func(target *Table) {
+		target.config.Behavior.Structs.AutoHeader = state
+		if target.logger != nil {
+			target.logger.Debugf("Option: WithStructsAutoHeader applied to Table: %v", state)
 		}
 	}
 }


### PR DESCRIPTION
Makes it a bit easier to use then using
```
table := tablewriter.NewTable(output.w, tablewriter.WithConfig(tablewriter.NewConfigBuilder().WithRowAutoWrap(tw.WrapNone).Behavior().WithAutoHeader(tw.On).Build().Build()))
```