### PR TITLE
Fix AlignRight override for footer HMerge/TOTAL pattern

### DIFF
--- a/renderer/colorized.go
+++ b/renderer/colorized.go
@@ -625,7 +625,7 @@ func (c *Colorized) renderLine(ctx tw.Formatting, line []string, tint Tint) {
 		}
 		// Override alignment for footer merges or TOTAL pattern
 		if (ctx.Row.Position == tw.Footer && isHMergeStart) || isTotalPattern {
-			if align != tw.AlignRight {
+			if align == tw.AlignNone {
 				c.logger.Debugf("renderLine: Applying AlignRight override for Footer HMerge/TOTAL pattern at col %d. Original/default align was: %s", i, align)
 				align = tw.AlignRight
 			}


### PR DESCRIPTION
I applied the logic used in `blueprint.go` to remove the override to AlignRight when footer alignment is set specifically. 
Not sure if we can combine the 2 `if align == tw.AlignNone {` statements, please advise if it's needed