### PR TITLE
move form rows [][][]string  to  [][]string solidify #290

### DIFF
--- a/tablewriter.go
+++ b/tablewriter.go
@@ -23,7 +23,7 @@ import (
 type Table struct {
 	writer       io.Writer           // Destination for table output
 	counters     []tw.Counter        // Counters for indices
-	rows         [][][]string        // Row data, supporting multi-line cells
+	rows         [][]string          // Row data, one slice of strings per logical row
 	headers      [][]string          // Header content
 	footers      [][]string          // Footer content
 	headerWidths tw.Mapper[int, int] // Computed widths for header columns
@@ -221,13 +221,12 @@ func (t *Table) Append(rows ...interface{}) error {
 		}
 	}
 
-	// The rest of the function proceeds as before, converting the data to string lines.
-	lines, err := t.toStringLines(cellsSource, t.config.Row)
+	cells, err := t.convertCellsToStrings(cellsSource, t.config.Row)
 	if err != nil {
 		t.logger.Errorf("Append (Batch) failed for cellsSource %v: %v", cellsSource, err)
 		return err
 	}
-	t.rows = append(t.rows, lines)
+	t.rows = append(t.rows, cells)
 
 	t.logger.Debugf("Append (Batch) completed for one row, total rows in table: %d", len(t.rows))
 	return nil
@@ -456,7 +455,7 @@ func (t *Table) Reset() {
 	t.logger.Debug("Reset() called. Clearing table data and render state.")
 
 	// Clear data slices
-	t.rows = nil    // Or t.rows = make([][][]string, 0)
+	t.rows = nil    // Or t.rows = make([][]string, 0)
 	t.headers = nil // Or t.headers = make([][]string, 0)
 	t.footers = nil // Or t.footers = make([][]string, 0)
 
@@ -556,16 +555,14 @@ func (t *Table) appendSingle(row interface{}) error {
 		t.logger.Debugf("appendSingle: Dispatching to streamAppendRow for row: %v", row)
 		return t.streamAppendRow(row) // Call the streaming render function
 	}
-	// Existing batch logic:
+
 	t.logger.Debugf("appendSingle: Processing for batch mode, row: %v", row)
-	// toStringLines now uses the new convertCellsToStrings internally, then prepareContent.
-	// This is fine for batch.
-	lines, err := t.toStringLines(row, t.config.Row)
+	cells, err := t.convertCellsToStrings(row, t.config.Row)
 	if err != nil {
-		t.logger.Debugf("Error in toStringLines (batch mode): %v", err)
+		t.logger.Debugf("Error in convertCellsToStrings (batch mode): %v", err)
 		return err
 	}
-	t.rows = append(t.rows, lines) // Add to batch storage
+	t.rows = append(t.rows, cells) // Add to batch storage
 	t.logger.Debugf("Row appended to batch t.rows, total batch rows: %d", len(t.rows))
 	return nil
 }
@@ -775,8 +772,8 @@ func (t *Table) maxColumns() int {
 		m = len(t.headers[0])
 	}
 	for _, row := range t.rows {
-		if len(row) > 0 && len(row[0]) > m {
-			m = len(row[0])
+		if len(row) > m {
+			m = len(row)
 		}
 	}
 	if len(t.footers) > 0 && len(t.footers[0]) > m {
@@ -811,7 +808,7 @@ func (t *Table) printTopBottomCaption(w io.Writer, actualTableWidth int) {
 		t.logger.Debugf("[printCaption] Empty table, no user caption.Width: Using natural caption width %d.", captionWrapWidth)
 	} else {
 		captionWrapWidth = actualTableWidth
-		t.logger.Debugf("[printCaption] Non-empty table, no user caption.Width: Using actualTableWidth %d for wrapping.", actualTableWidth)
+		t.logger.Debugf("[printCaption] Non-empty table, no user caption.Width: Using actualTableWidth %d for wrapping.", captionWrapWidth)
 	}
 
 	if captionWrapWidth <= 0 {
@@ -1066,13 +1063,20 @@ func (t *Table) prepareContexts() (*renderContext, *mergeContext, error) {
 		logger: t.logger,
 	}
 
-	isEmpty, visibleCount := t.getEmptyColumnInfo(numOriginalCols)
+	// Process raw rows into visual, multi-line rows
+	processedRowLines := make([][][]string, len(t.rows))
+	for i, rawRow := range t.rows {
+		processedRowLines[i] = t.prepareContent(rawRow, t.config.Row)
+	}
+	ctx.rowLines = processedRowLines
+
+	isEmpty, visibleCount := t.getEmptyColumnInfo(ctx.rowLines, numOriginalCols)
 	ctx.emptyColumns = isEmpty
 	ctx.visibleColCount = visibleCount
 
 	mctx := &mergeContext{
 		headerMerges: make(map[int]tw.MergeState),
-		rowMerges:    make([]map[int]tw.MergeState, len(t.rows)),
+		rowMerges:    make([]map[int]tw.MergeState, len(ctx.rowLines)),
 		footerMerges: make(map[int]tw.MergeState),
 		horzMerges:   make(map[tw.Position]map[int]bool),
 	}
@@ -1081,7 +1085,6 @@ func (t *Table) prepareContexts() (*renderContext, *mergeContext, error) {
 	}
 
 	ctx.headerLines = t.headers
-	ctx.rowLines = t.rows
 	ctx.footerLines = t.footers
 
 	if err := t.calculateAndNormalizeWidths(ctx); err != nil {
@@ -1095,14 +1098,15 @@ func (t *Table) prepareContexts() (*renderContext, *mergeContext, error) {
 	ctx.headerLines = preparedHeaderLines
 	mctx.headerMerges = headerMerges
 
-	processedRowLines := make([][][]string, len(ctx.rowLines))
+	// Re-process row lines for merges now that widths are known
+	processedRowLinesWithMerges := make([][][]string, len(ctx.rowLines))
 	for i, row := range ctx.rowLines {
 		if mctx.rowMerges[i] == nil {
 			mctx.rowMerges[i] = make(map[int]tw.MergeState)
 		}
-		processedRowLines[i], mctx.rowMerges[i], _ = t.prepareWithMerges(row, t.config.Row, tw.Row)
+		processedRowLinesWithMerges[i], mctx.rowMerges[i], _ = t.prepareWithMerges(row, t.config.Row, tw.Row)
 	}
-	ctx.rowLines = processedRowLines
+	ctx.rowLines = processedRowLinesWithMerges
 
 	t.applyHorizontalMergeWidths(tw.Header, ctx, mctx.headerMerges)
 


### PR DESCRIPTION
Currently, we are splitting rows before applying modifications; however, some of these modifications have to do with spaces and newlines, which is why we are using `[][][]string`. This can be problematic, so instead of saving the modified rows, we should leave the rows as they are in `[][]string`, apply the modifications, and then send them directly to the renderer.
