### PR TITLE
feat: Update displaywidth and related dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/olekukonko/tablewriter
 go 1.21
 
 require (
-	github.com/clipperhouse/displaywidth v0.3.1
-	github.com/clipperhouse/uax29/v2 v2.2.0
+	github.com/clipperhouse/displaywidth v0.5.0
+	github.com/clipperhouse/uax29/v2 v2.3.0
 	github.com/fatih/color v1.15.0
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/olekukonko/errors v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
-github.com/clipperhouse/displaywidth v0.3.1 h1:k07iN9gD32177o1y4O1jQMzbLdCrsGJh+blirVYybsk=
-github.com/clipperhouse/displaywidth v0.3.1/go.mod h1:tgLJKKyaDOCadywag3agw4snxS5kYEuYR6Y9+qWDDYM=
+github.com/clipperhouse/displaywidth v0.5.0 h1:AIG5vQaSL2EKqzt0M9JMnvNxOCRTKUc4vUnLWGgP89I=
+github.com/clipperhouse/displaywidth v0.5.0/go.mod h1:R+kHuzaYWFkTm7xoMmK1lFydbci4X2CicfbGstSGg0o=
 github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=
 github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
-github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
-github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
+github.com/clipperhouse/uax29/v2 v2.3.0 h1:SNdx9DVUqMoBuBoW3iLOj4FQv3dN5mDtuqwuhIGpJy4=
+github.com/clipperhouse/uax29/v2 v2.3.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
@@ -17,8 +17,6 @@ github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6/go.mod h1:rEKTHC9roVVicUIfZK7DYrdIoM0EOr8mK1Hj5s3JjH0=
 github.com/olekukonko/errors v1.1.0 h1:RNuGIh15QdDenh+hNvKrJkmxxjV4hcS50Db478Ou5sM=
 github.com/olekukonko/errors v1.1.0/go.mod h1:ppzxA5jBKcO1vIpCXQ9ZqgDh8iwODz6OXIGKU8r5m4Y=
-github.com/olekukonko/ll v0.1.1 h1:9Dfeed5/Mgaxb9lHRAftLK9pVfYETvHn+If6lywVhJc=
-github.com/olekukonko/ll v0.1.1/go.mod h1:2dJo+hYZcJMLMbKwHEWvxCUbAOLc/CXWS9noET22Mdo=
 github.com/olekukonko/ll v0.1.2 h1:lkg/k/9mlsy0SxO5aC+WEpbdT5K83ddnNhAepz7TQc0=
 github.com/olekukonko/ll v0.1.2/go.mod h1:b52bVQRRPObe+yyBl0TxNfhesL0nedD4Cht0/zx55Ew=
 github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0 h1:LiZB1h0GIcudcDci2bxbqI6DXV8bF8POAnArqvRrIyw=

--- a/pkg/twwidth/width.go
+++ b/pkg/twwidth/width.go
@@ -29,8 +29,7 @@ func newOptions() displaywidth.Options {
 	// we want to keep that compatibility
 	cond := runewidth.NewCondition()
 	options := displaywidth.Options{
-		EastAsianWidth:     cond.EastAsianWidth,
-		StrictEmojiNeutral: cond.StrictEmojiNeutral,
+		EastAsianWidth: cond.EastAsianWidth,
 	}
 	return options
 }
@@ -105,8 +104,7 @@ func SetCondition(cond *runewidth.Condition) {
 // Convert runewidth.Condition to displaywidth.Options
 func conditionToOptions(cond *runewidth.Condition) displaywidth.Options {
 	return displaywidth.Options{
-		EastAsianWidth:     cond.EastAsianWidth,
-		StrictEmojiNeutral: cond.StrictEmojiNeutral,
+		EastAsianWidth: cond.EastAsianWidth,
 	}
 }
 

--- a/pkg/twwidth/width_test.go
+++ b/pkg/twwidth/width_test.go
@@ -326,12 +326,6 @@ func TestNewOptions(t *testing.T) {
 		t.Errorf("newOptions().EastAsianWidth = %v, want %v (from runewidth.NewCondition())",
 			options.EastAsianWidth, cond.EastAsianWidth)
 	}
-
-	// Verify that StrictEmojiNeutral is correctly copied from runewidth condition
-	if options.StrictEmojiNeutral != cond.StrictEmojiNeutral {
-		t.Errorf("newOptions().StrictEmojiNeutral = %v, want %v (from runewidth.NewCondition())",
-			options.StrictEmojiNeutral, cond.StrictEmojiNeutral)
-	}
 }
 
 func TestNewOptionsWithEnvironment(t *testing.T) {
@@ -399,11 +393,6 @@ func TestNewOptionsWithEnvironment(t *testing.T) {
 			if options.EastAsianWidth != cond.EastAsianWidth {
 				t.Errorf("newOptions().EastAsianWidth = %v, want %v (from runewidth.NewCondition() with env: RUNEWIDTH_EASTASIAN=%s, LC_ALL=%s)",
 					options.EastAsianWidth, cond.EastAsianWidth, tc.runewidthEA, tc.locale)
-			}
-
-			if options.StrictEmojiNeutral != cond.StrictEmojiNeutral {
-				t.Errorf("newOptions().StrictEmojiNeutral = %v, want %v (from runewidth.NewCondition() with env: RUNEWIDTH_EASTASIAN=%s, LC_ALL=%s)",
-					options.StrictEmojiNeutral, cond.StrictEmojiNeutral, tc.runewidthEA, tc.locale)
 			}
 		})
 	}

--- a/tests/extra_test.go
+++ b/tests/extra_test.go
@@ -361,7 +361,7 @@ func TestEmojiTable(t *testing.T) {
 │  NAME  😺  │ AGE  🎂  │  CITY  🌍   │
 ├────────────┼──────────┼─────────────┤
 │ Alice 😊   │ 25       │ New York 🌆 │
-│ Bob 😎     │ 30       │ Boston 🏙️    │
+│ Bob 😎     │ 30       │ Boston 🏙️   │
 │ Charlie 🤓 │ 28       │ Tokyo 🗼    │
 ├────────────┼──────────┼─────────────┤
 │            │ Total 👥 │           3 │


### PR DESCRIPTION
# chore(deps): Update displaywidth and related dependencies

This PR updates several dependencies, most notably `github.com/clipperhouse/displaywidth`, and adapts the code to the latest versions.

### Description

The primary motivation for this change is to update our dependencies to their latest versions. A key change is in `github.com/clipperhouse/displaywidth` (updated from `v0.3.1` to `v0.5.0`), which removed the `StrictEmojiNeutral` field from its `Options` struct.

This required the following adjustments:

*   **Dependency Updates**: Updated `go.mod` and `go.sum` to reflect the new versions of `github.com/clipperhouse/displaywidth` and `github.com/clipperhouse/uax29/v2`.
*   **Code Adaptation**: Removed the usage of the `StrictEmojiNeutral` field in `pkg/twwidth/width.go` when creating `displaywidth.Options`.
*   **Test Updates**: The corresponding tests in `pkg/twwidth/width_test.go` were updated to remove checks for the now-removed field.
*   **Rendering Fix**: Updated a test case in `tests/extra_test.go` to match the corrected emoji width rendering provided by the new dependency version.

This change ensures the project stays current with its dependencies and resolves a breaking API change.