### PR TITLE
fix: width reduction loops skip minimum-width columns correctly

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -673,12 +673,24 @@ func (t *Table) streamCalculateWidths(sampling []string, config tw.CellConfig) i
 				})
 				if len(colsToAdjust) > 0 {
 					for i := 0; i < int(math.Abs(float64(remainingSpace))); i++ {
-						colIdx := colsToAdjust[i%len(colsToAdjust)]
-						currentColWidth := t.streamWidths.Get(colIdx)
 						if remainingSpace > 0 {
+							colIdx := colsToAdjust[i%len(colsToAdjust)]
+							currentColWidth := t.streamWidths.Get(colIdx)
 							t.streamWidths.Set(colIdx, currentColWidth+1)
-						} else if remainingSpace < 0 && currentColWidth > 1 { // Don't reduce below 1
-							t.streamWidths.Set(colIdx, currentColWidth-1)
+						} else {
+							// Find next column that can be reduced (skip columns already at minimum width)
+							reduced := false
+							for j := 0; j < len(colsToAdjust); j++ {
+								colIdx := colsToAdjust[(i+j)%len(colsToAdjust)]
+								if t.streamWidths.Get(colIdx) > 1 {
+									t.streamWidths.Set(colIdx, t.streamWidths.Get(colIdx)-1)
+									reduced = true
+									break
+								}
+							}
+							if !reduced {
+								break // All columns at minimum width, no further reduction possible
+							}
 						}
 					}
 				}

--- a/tests/bug_test.go
+++ b/tests/bug_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/olekukonko/tablewriter"
+	"github.com/olekukonko/tablewriter/pkg/twwidth"
 	"github.com/olekukonko/tablewriter/renderer"
 	"github.com/olekukonko/tablewriter/tw"
 )
@@ -600,4 +601,117 @@ func TestBugRenditionDebugLeak(t *testing.T) {
 			t.Errorf("debug output leaked from Ocean.Rendition despite WithDebug(false):\n%s", debugBuf.String())
 		}
 	})
+}
+
+// TestBugStreamWidthReduction tests that streaming mode correctly reduces column widths
+// to respect the global width constraint, even when multiple columns are at minimum width
+// and the round-robin distribution needs to skip them to find reducible columns.
+func TestBugStreamWidthReduction(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		global  int
+		headers []string
+		row     []string
+	}{
+		{
+			name:    "NarrowWith5Cols",
+			global:  12,
+			headers: []string{"AAAAAA", "BB", "CC", "DD", "EE"},
+			row:     []string{"123456", "12", "12", "12", "12"},
+		},
+		{
+			name:    "VeryNarrowWith3Cols",
+			global:  10,
+			headers: []string{"Name", "Value", "X"},
+			row:     []string{"LongNameHere", "SomeValue!", "Y"},
+		},
+		{
+			name:    "TightWith4Cols",
+			global:  10,
+			headers: []string{"AA", "BB", "CC", "DD"},
+			row:     []string{"11", "22", "33", "44"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			st := createStreamTable(t, &buf,
+				tablewriter.WithConfig(tablewriter.Config{
+					Row: tw.CellConfig{
+						Formatting: tw.CellFormatting{AutoWrap: tw.WrapTruncate},
+					},
+					Stream: tw.StreamConfig{Enable: true},
+					Widths: tw.CellWidth{Global: tt.global},
+				}),
+			)
+			if err := st.Start(); err != nil {
+				t.Fatalf("Start failed: %v", err)
+			}
+			st.Header(tt.headers)
+			st.Append(tt.row)
+			if err := st.Close(); err != nil {
+				t.Fatalf("Close failed: %v", err)
+			}
+
+			output := buf.String()
+			lines := strings.Split(strings.TrimSpace(output), "\n")
+			for i, line := range lines {
+				// Subtract 2 for left and right border characters
+				lineWidth := twwidth.Width(line) - 2
+				if lineWidth > tt.global {
+					t.Errorf("line %d exceeds global width %d (got %d): %s", i, tt.global, lineWidth, line)
+				}
+			}
+		})
+	}
+}
+
+// TestBugMergedHeaderOverDistribution tests that batch mode correctly handles
+// over-distribution correction when merging headers, terminating early when
+// no eligible columns remain for reduction.
+func TestBugMergedHeaderOverDistribution(t *testing.T) {
+	var buf bytes.Buffer
+	table := tablewriter.NewTable(&buf,
+		tablewriter.WithConfig(tablewriter.Config{
+			Header: tw.CellConfig{
+				Merging: tw.CellMerging{Mode: tw.MergeHorizontal},
+			},
+		}),
+		tablewriter.WithRenderer(renderer.NewBlueprint(tw.Rendition{
+			Settings: tw.Settings{
+				Separators: tw.Separators{BetweenRows: tw.Off},
+			},
+		})),
+	)
+	// Short merged header spanning many columns with narrow content
+	table.Header([]string{"Merged", "Merged", "Merged", "Merged"})
+	table.Append([]string{"A", "B", "C", "D"})
+	table.Append([]string{"1", "2", "3", "4"})
+	table.Render()
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+
+	// All lines should have the same width (consistent table rendering)
+	if len(lines) == 0 {
+		t.Fatal("no output lines")
+	}
+	firstWidth := twwidth.Width(lines[0])
+	for i, line := range lines {
+		w := twwidth.Width(line)
+		if w != firstWidth {
+			t.Errorf("line %d has width %d, expected %d: %s", i, w, firstWidth, line)
+		}
+	}
+
+	expected := `
+		┌───────────────────────────────────┐
+		│              MERGED               │
+		├────────┬────────┬────────┬────────┤
+		│ A      │ B      │ C      │ D      │
+		│ 1      │ 2      │ 3      │ 4      │
+		└────────┴────────┴────────┴────────┘
+	`
+	if !visualCheck(t, "MergedHeaderOverDistribution", output, expected) {
+		t.Error(table.Debug())
+	}
 }

--- a/zoo.go
+++ b/zoo.go
@@ -795,14 +795,20 @@ func (t *Table) calculateAndNormalizeWidths(ctx *renderContext) error {
 						// Sort columns for deterministic reduction
 						sortedCols := workingWidths.SortedKeys()
 						for i := 0; i < overDistributed; i++ {
+							reduced := false
 							// Reduce from highest-indexed column
 							for j := len(sortedCols) - 1; j >= 0; j-- {
 								col := sortedCols[j]
 								if workingWidths.Get(col) > 1 && naturalColumnWidths.Get(col) < workingWidths.Get(col) {
 									workingWidths.Set(col, workingWidths.Get(col)-1)
 									ctx.logger.Debugf("Reduced col %d by 1 to %d", col, workingWidths.Get(col))
+									reduced = true
 									break
 								}
+							}
+							if !reduced {
+								// No eligible column found, no further reduction possible
+								break
 							}
 						}
 					}


### PR DESCRIPTION
Both streaming mode (stream.go) and batch mode (zoo.go) have round-robin loops that distribute negative width adjustments across columns. When a column is already at minimum width (1), the loop skipped it but did not try other columns that might still be reducible. This caused the final width sum to exceed the target under tight global width constraints.

Streaming: the round-robin now scans forward to find the next reducible column instead of silently skipping.
Batch: the merged header over-distribution correction now terminates early when no eligible column remains.

Tests added in tests/bug_test.go for both cases.