### PR TITLE
fix(svg): size columns by display width for wide (CJK) runes

### DIFF
--- a/renderer/svg.go
+++ b/renderer/svg.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/olekukonko/ll"
 
+	"github.com/olekukonko/tablewriter/pkg/twwidth"
 	"github.com/olekukonko/tablewriter/tw"
 )
 
@@ -384,10 +385,13 @@ func (s *SVG) Debug() []string {
 
 // estimateTextWidth estimates text width in SVG units.
 // Parameter text is the input string to measure.
-// Returns the estimated width based on font size and char factor.
+// Returns the estimated width based on the text's display width, font size,
+// and char factor. Display width is used (instead of the rune count) so that
+// wide runes such as CJK characters, which occupy two cells, are sized as two
+// columns rather than one.
 func (s *SVG) estimateTextWidth(text string) float64 {
-	runeCount := float64(len([]rune(text)))
-	return runeCount * s.config.FontSize * s.config.ApproxCharWidthFactor
+	displayWidth := float64(twwidth.Width(text))
+	return displayWidth * s.config.FontSize * s.config.ApproxCharWidthFactor
 }
 
 // Footer buffers footer lines for SVG rendering.

--- a/tests/svg_cjk_test.go
+++ b/tests/svg_cjk_test.go
@@ -1,0 +1,49 @@
+package tests
+
+import (
+	"bytes"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/olekukonko/tablewriter/renderer"
+)
+
+var svgRootWidthRe = regexp.MustCompile(`<svg[^>]*\bwidth="([0-9.]+)"`)
+
+// svgRootWidth renders a single-column SVG table whose only cell is content and
+// returns the width of the root <svg> element.
+func svgRootWidth(t *testing.T, content string) float64 {
+	t.Helper()
+	var buf bytes.Buffer
+	svgCfg := defaultSVGConfigForTests(false)
+	table := tablewriter.NewTable(&buf, tablewriter.WithRenderer(renderer.NewSVG(svgCfg)))
+	table.Append([]string{content})
+	table.Render()
+
+	m := svgRootWidthRe.FindStringSubmatch(buf.String())
+	if m == nil {
+		t.Fatalf("no width attribute found in SVG output:\n%s", buf.String())
+	}
+	w, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		t.Fatalf("failed to parse width %q: %v", m[1], err)
+	}
+	return w
+}
+
+// TestSVGWideRuneColumnWidth verifies that the SVG renderer sizes columns by
+// the display width of the content, so that wide (CJK) runes which occupy two
+// terminal cells are not packed into half the space they need. A cell of four
+// fullwidth runes has the same display width as eight ASCII characters and so
+// must produce an equally wide column. Sizing by rune count would make the CJK
+// column too narrow and the text would overflow its cell.
+func TestSVGWideRuneColumnWidth(t *testing.T) {
+	wide := svgRootWidth(t, "ああああ")      // 4 fullwidth runes, display width 8
+	ascii := svgRootWidth(t, "abcdefgh") // 8 ASCII runes, display width 8
+
+	if wide != ascii {
+		t.Errorf("CJK column sized by rune count, not display width: width(ああああ)=%v, width(abcdefgh)=%v; want equal", wide, ascii)
+	}
+}

--- a/tests/svg_cjk_test.go
+++ b/tests/svg_cjk_test.go
@@ -47,3 +47,51 @@ func TestSVGWideRuneColumnWidth(t *testing.T) {
 		t.Errorf("CJK column sized by rune count, not display width: width(ああああ)=%v, width(abcdefgh)=%v; want equal", wide, ascii)
 	}
 }
+
+// TestSVGMixedWidthColumnWidth verifies that a cell mixing ASCII and fullwidth
+// runes is sized by the sum of their display widths rather than the rune count.
+// "aあ" is one ASCII cell plus one fullwidth (two-cell) rune, a display width of
+// three, the same as three ASCII characters. Sizing by rune count would treat
+// "aあ" as two runes and make the column too narrow.
+func TestSVGMixedWidthColumnWidth(t *testing.T) {
+	mixed := svgRootWidth(t, "aあ")  // display width 1 + 2 = 3
+	ascii := svgRootWidth(t, "abc") // display width 3
+
+	if mixed != ascii {
+		t.Errorf("mixed cell sized by rune count, not display width: width(aあ)=%v, width(abc)=%v; want equal", mixed, ascii)
+	}
+}
+
+// TestSVGWideRuneColumnWidthScales verifies the display-width sizing holds at
+// several lengths, so a run of n fullwidth runes matches 2n ASCII characters
+// and not only at one particular length.
+func TestSVGWideRuneColumnWidthScales(t *testing.T) {
+	cases := []struct {
+		wide  string
+		ascii string
+	}{
+		{"中", "ab"},
+		{"中文", "abcd"},
+		{"中文字", "abcdef"},
+	}
+	for _, c := range cases {
+		wide := svgRootWidth(t, c.wide)
+		ascii := svgRootWidth(t, c.ascii)
+		if wide != ascii {
+			t.Errorf("width(%q)=%v, width(%q)=%v; want equal", c.wide, wide, c.ascii, ascii)
+		}
+	}
+}
+
+// TestSVGCombiningMarkColumnWidth verifies that combining marks, which occupy no
+// display cells of their own, do not widen a column. "é" (e followed by a
+// combining acute accent) has the display width of a single "e" even though it
+// is two runes; sizing by rune count would make the column too wide.
+func TestSVGCombiningMarkColumnWidth(t *testing.T) {
+	combining := svgRootWidth(t, "é") // e + combining acute, display width 1
+	plain := svgRootWidth(t, "e")      // display width 1
+
+	if combining != plain {
+		t.Errorf("combining mark widened the column: width(e+U+0301)=%v, width(e)=%v; want equal", combining, plain)
+	}
+}


### PR DESCRIPTION
The SVG renderer sizes each column from `estimateTextWidth`, which multiplied the rune count by the font size and `ApproxCharWidthFactor`. Wide runes (CJK and other fullwidth characters) take up two cells but count as one rune, so a column holding that text gets about half the width it needs and the text spills past the cell border.

The rest of the package already measures text with `twwidth.Width` (display width), so this makes `estimateTextWidth` use it too. ASCII output is unchanged, since `Width` returns the rune count for single-cell characters, and the existing SVG golden tests stay green.

Repro: render a one-column table whose cell is `ああああ` (four fullwidth runes, display width 8) and one whose cell is `abcdefgh` (also display width 8). Before this change the first column comes out about half the width of the second; after, they match.

`TestSVGWideRuneColumnWidth` covers that case.
